### PR TITLE
Revert "Add an informative reference to WEBGL_texture_from_depth_video."

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,20 +69,7 @@
             href: "https://github.com/w3c/mediacapture-depth/commits/"
           }
         ]
-        }],
-        localBiblio: {
-          "WEBGLDEPTH": {
-              title:     "WebGL WEBGL_texture_from_depth_video Extension",
-              href:      "https://www.khronos.org/registry/webgl/extensions/proposals/WEBGL_texture_from_depth_video/",
-              authors:  [
-                "Ningxin Hu",
-                "Anssi Kostiainen",
-                "Rob Manson"
-              ],
-              status:    "Proposed Extension Specification",
-              publisher: "Khronos"
-          }
-        }
+        }]
     };
 
     </script>
@@ -190,12 +177,6 @@
         interface and <code><a href=
         "http://www.w3.org/html/wg/drafts/2dcontext/master/#canvasimagesource">
         <dfn>CanvasImageSource</dfn></a></code> typedef are defined in [[!2DCONTEXT2]].
-      </p>
-      <p>
-        The <code><a href=
-        "https://www.khronos.org/registry/webgl/extensions/proposals/WEBGL_texture_from_depth_video/">
-        <dfn>WEBGL_texture_from_depth_video</dfn></a></code> interface is
-        defined in [[WEBGLDEPTH]].
       </p>
       <p>
         The <code><a href=


### PR DESCRIPTION
This reverts commit 65059232e0ecbf4854055d676f9111dc166a60bc.

BUG=https://github.com/w3c/mediacapture-depth/issues/38
