### PR TITLE
Proposal for FrameGrabber, FrameData, DepthMap

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,30 +351,6 @@
             -
           </dd>
           <dt>
-            readonly attribute string format
-          </dt>
-          <dd>
-            -
-          </dd>
-          <dt>
-            readonly attribute string units
-          </dt>
-          <dd>
-            -
-          </dd>
-          <dt>
-            readonly attribute float near
-          </dt>
-          <dd>
-            -
-          </dd>
-          <dt>
-            readonly attribute float far
-          </dt>
-          <dd>
-            -
-          </dd>
-          <dt>
             readonly attribute Uint16Array data
           </dt>
           <dd>
@@ -515,6 +491,30 @@
           </dd>
           <dt>
             double verticalFieldOfView = null
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            double format = null
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            double units = null
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            double near = null
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            double far = null
           </dt>
           <dd>
             -

--- a/index.html
+++ b/index.html
@@ -544,56 +544,6 @@
         Examples
       </h2>
       <h3>
-        2D Canvas Context based post-processing
-      </h3>
-      <pre class='example highlight'>
-var canvasContext = document.createElement("canvas").getContext("2d");
-
-navigator.mediaDevices.getUserMedia({
-  video: true,
-  depth: true,
-}).then(function (stream) {
-  // wire the stream into a &lt;video&gt; element for playback
-  var video = document.querySelector('#video');
-  video.srcObject = stream;
-  video.play();
-  // wire the depth stream into another &lt;video&gt; element to convert kind
-  // NOTE: Only the R and G bytes are set to carry 16 bits of data
-  var depthVideo = document.querySelector('#depthVideo');
-  // construct a new MediaStream out of the existing depth track(stream)
-  var depthStream = new MediaStream(stream.getDepthTracks()[0]);
-  depthVideo.srcObject = depthStream;
-  depthVideo.play();
-
-  depthVideo.onloadedmetadata = function () {
-    function doSomething() {
-      canvasContext.drawImage(video);
-      var rgbImageData = canvasContext.getImageData(0, 0, w, h);
-      var pixels = rgbImageData.data;
-      canvasContext.drawImage(depthVideo);
-      var depthImageData = canvasContext.getImageData(0, 0, w, h);
-      var dexels = depthImageData.data;
-
-      // iterate through depth pixels to convert 2 bytes into 1 Uint16
-      for (var x = 0; x &lt; w ; ++x) {
-        for (var y = 0; y &lt; h; ++y) {
-          var i = (x + y * w) * 4;
-          // combine the R &amp; G pixels at (x, y) to get
-          // the 16 bit depth pixel value
-          var depth = dexels[i] | dexels[i + 1] &lt;&lt; 8;
-        }
-      }
-      // do things with pixels and dexels here
-      window.requestAnimationFrame(doSomething);
-    }
-    window.requestAnimationFrame(doSomething);
-  };
-}).catch(function (reason) {
-  // handle gUM error here
-});
-      
-</pre>
-      <h3>
         WebGL Fragment Shader based post-processing
       </h3>
       <pre class='example highlight'>

--- a/index.html
+++ b/index.html
@@ -316,45 +316,6 @@
       </section>
       <section>
         <h2>
-          <code>ImageData</code> interface
-        </h2>
-        <div class="note">
-          <p>
-            Depth cameras usually produce 16-bit depth values per pixel.
-            However, the canvas drawing surface used to draw and manipulate 2D
-            graphics on the web platform does not currently support 16bpp.
-          </p>
-          <p>
-            To address the issue, this specification defines a new data
-            representation for current <a>Canvas Pixel
-            <code>ArrayBuffer</code></a> of <code><a>ImageData</a></code>
-            interface to represent the 16bpp depth image produced by depth
-            cameras.
-          </p>
-        </div>
-        <p>
-          An <code><a>ImageData</a></code> object is said to <dfn>represent
-          depth data</dfn>, when the <a><code>CanvasImageSource</code></a> used
-          as the image source for the
-          <a><code>CanvasRenderingContext2D</code></a> is a <a>depth video
-          element</a>.
-        </p>
-        <p>
-          When representing a depth image, the <dfn>Canvas Pixel
-          <code>ArrayBuffer</code></dfn> is an <a><code>ArrayBuffer</code></a>
-          whose data is represented in left-to-right order, row by row top to
-          bottom, starting with the top left, with each pixel's lower 8 bit of
-          16 bit depth value, upper 8 bit of 16 bit depth value, 8 bit reserved
-          data, and another 8 bit reserved data being given in that order for
-          each pixel. Each component of each pixel represented in this array
-          must be in the range 0..255, representing the 8 bit value for that
-          component. The components must be assigned consecutive indices
-          starting with 0 for the top left pixel's lower 8 bit of 16 bit depth
-          value component.
-        </p>
-      </section>
-      <section>
-        <h2>
           <code>Settings</code> dictionary
         </h2>
         <p>

--- a/index.html
+++ b/index.html
@@ -316,6 +316,74 @@
       </section>
       <section>
         <h2>
+          <code>DepthData</code> interface
+        </h2>
+        <div class="note">
+          <p>
+            Depth cameras usually produce 16-bit depth values per pixel.
+            However, neither the canvas drawing surface used to draw and
+            manipulate 2D graphics on the web platform nor the
+            <code><a>ImageData</a></code> interface used to represent image
+            data support 16 bpp.
+          </p>
+          <p>
+            To address the issue, this specification defines a new
+            <code><a>DepthData</a></code> interface.
+          </p>
+        </div>
+        <dl class="idl" title="interface DepthData">
+          <dt>
+            readonly attribute unsigned long width
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute unsigned long height
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute string type
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute string format
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute string units
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute float near
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute float far
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute Uint16Array data
+          </dt>
+          <dd>
+            -
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h2>
           <code>Settings</code> dictionary
         </h2>
         <p>

--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@
             -
           </dd>
           <dt>
-            readonly attribute string type
+            readonly attribute string measureType
           </dt>
           <dd>
             -

--- a/index.html
+++ b/index.html
@@ -421,6 +421,47 @@
       </section>
       <section>
         <h2>
+          <code>FrameGrabber</code> interface
+        </h2>
+        <dl class="idl" title=
+        "[Constructor(MediaStream stream)] interface FrameGrabber">
+          <dt>
+            readonly attribute MediaStream stream
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            void start()
+          </dt>
+          <dd>
+            <dl class="parameters">
+              <dt>
+                FrameGrabberCallback callback
+              </dt>
+              <dd>
+                -
+              </dd>
+              <dt>
+                optional double fps
+              </dt>
+              <dd>
+                -
+              </dd>
+            </dl>
+          </dd>
+          <dt>
+            void stop()
+          </dt>
+          <dd>
+            -
+          </dd>
+        </dl>
+        <dl class="idl" title=
+        "callback FrameGrabberCallback = void (FrameData frameData)"></dl>
+      </section>
+      <section>
+        <h2>
           <code>Settings</code> dictionary
         </h2>
         <p>

--- a/index.html
+++ b/index.html
@@ -163,10 +163,10 @@
         The <code><a href=
         "http://w3c.github.io/mediacapture-main/getusermedia.html#idl-def-Constraints">
         <dfn>Constraints</dfn></a></code>, <code><a href=
-        "http://w3c.github.io/mediacapture-main/getusermedia.html#dfn-settings">
-        <dfn>Settings</dfn></a></code>, <code><a href=
         "http://w3c.github.io/mediacapture-main/getusermedia.html#idl-def-MediaStreamConstraints">
-        <dfn>MediaStreamConstraints</dfn></a></code>, and <code><a href=
+        <dfn>MediaStreamConstraints</dfn></a></code>, <code><a href=
+        "http://w3c.github.io/mediacapture-main/getusermedia.html#idl-def-MediaTrackSettings">
+        <dfn>MediaTrackSettings</dfn></a></code>, and <code><a href=
         "http://w3c.github.io/mediacapture-main/getusermedia.html#idl-def-MediaTrackConstraints">
         <dfn>MediaTrackConstraints</dfn></a></code> dictionaries this
         specification extends are based upon the <a href=
@@ -537,20 +537,16 @@
       </section>
       <section>
         <h2>
-          <code>Settings</code> dictionary
+          <code>MediaTrackSettings</code> dictionary
         </h2>
         <p>
           When the <code>getSettings()</code> method is invoked on a
           <a><code>MediaStreamTrack</code></a> object that represents a
-          <a>depth track</a>, the <a>user agent</a> MUST return a
-          <a><code>Settings</code></a> dictionary with the additional
-          properties listed below. When the <code>getSettings()</code> method
-          is invoked on a <a><code>MediaStreamTrack</code></a> object that
-          represents a <a>video track</a>, the <a>user agent</a> MAY return a
-          <code>Settings</code> dictionary with the additional properties
-          listed below:
+          <a>depth track</a>, the <a>user agent</a> MUST return the following
+          dictionary that extends the <a><code>MediaTrackSettings</code></a>
+          dictionary:
         </p>
-        <dl class="idl" title="partial dictionary Settings">
+        <dl class="idl" title="partial dictionary MediaTrackSettings">
           <dt>
             double focalLength = null
           </dt>

--- a/index.html
+++ b/index.html
@@ -351,12 +351,6 @@
             -
           </dd>
           <dt>
-            readonly attribute string measureType
-          </dt>
-          <dd>
-            -
-          </dd>
-          <dt>
             readonly attribute string format
           </dt>
           <dd>
@@ -411,27 +405,6 @@
           0..65535, representing the 16 bit value for that <a>dexel</a>. The
           <a title="dexel">dexels</a> MUST be assigned consecutive indices
           starting with 0 for the top left <a>dexel</a>.
-        </p>
-        <p>
-          The <dfn><code id=
-          "widl-DepthMap-measureType">measureType</code></dfn> attribute
-          represents the type of depth measurement. It can have the following
-          values:
-        </p>
-        <ul>
-          <li>
-            <dfn><code>opticalaxis</code></dfn>
-          </li>
-          <li>
-            <dfn><code>opticray</code></dfn>
-          </li>
-        </ul>
-        <p>
-          When the object is created, its <code><a>measureType</a></code> MUST
-          be set to string "<code><a>opticalaxis</a></code>", if the depth data
-          represents <a title="dexel">dexels</a> measured along the optical
-          axis, and to "<code><a>opticray</a></code>", if measured along the
-          optic ray.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -316,30 +316,6 @@
       </section>
       <section>
         <h2>
-          <code>CanvasImageSource</code> typedef
-        </h2>
-        <div class="note">
-          <p>
-            Several methods in the <a><code>CanvasRenderingContext2D</code></a>
-            API take the union type <a><code>CanvasImageSource</code></a> as an
-            argument. This specification extends the list of <a href=
-            "http://www.w3.org/html/wg/drafts/2dcontext/master/#image-sources-for-2d-rendering-contexts">
-            image sources for 2D rendering contexts</a> defined in
-            [[!2DCONTEXT2]].
-          </p>
-        </div>
-        <p>
-          A <code>video</code> element whose source is a
-          <code><a>MediaStream</a></code> object containing a <a>depth
-          track</a> is said to be a <dfn>depth video element</dfn>.
-        </p>
-        <p>
-          A <a>depth video element</a> may be used as a
-          <a><code>CanvasImageSource</code></a>.
-        </p>
-      </section>
-      <section>
-        <h2>
           <code>ImageData</code> interface
         </h2>
         <div class="note">

--- a/index.html
+++ b/index.html
@@ -538,6 +538,9 @@
         <dl class="idl" title=
         "callback FrameGrabberCallback = void (FrameData frameData)"></dl>
       </section>
+      <div class="note">
+        The <code><a>FrameGrabber</a></code> behavior needs to be defined.
+      </div>
       <section>
         <h2>
           <code>MediaTrackSettings</code> dictionary

--- a/index.html
+++ b/index.html
@@ -209,10 +209,6 @@
         other similar source.
       </p>
       <p>
-        A <dfn>depth map</dfn> is an image that contains information relating
-        to the distance of the surfaces of scene objects from a viewpoint.
-      </p>
-      <p>
         A <dfn>dexel</dfn> is a depth pixel in the <a>depth map</a>.
       </p>
     </section>
@@ -336,6 +332,72 @@
             <code><a>DepthMap</a></code> interface.
           </p>
         </div>
+        <p>
+          A <dfn>depth map</dfn> is an image that contains information relating
+          to the distance of the surfaces of scene objects from a viewpoint.
+        </p>
+        <p>
+          A <a>depth map</a> has an associated <dfn>focal length</dfn> which is
+          a double. It represents the focal length of the camera in
+          millimeters.
+        </p>
+        <p>
+          A <a>depth map</a> has an associated <dfn>horizontal field of
+          view</dfn> which is a double. It represents the horizontal angle of
+          view in degrees.
+        </p>
+        <p>
+          A <a>depth map</a> has an associated <dfn>vertical field of
+          view</dfn> which is a double. It represents the vertical angle of
+          view in degrees.
+        </p>
+        <p>
+          A <a>depth map</a> has an associated <dfn>format</dfn> which is a
+          DOMString. It represents the format of the <a>depth map</a>, and is
+          one of the following:
+        </p>
+        <dl>
+          <dt>
+            "<code><dfn>linear</dfn></code>"
+          </dt>
+          <dd>
+            TODO: describe
+          </dd>
+          <dt>
+            "<code><dfn>inverse</dfn></code>"
+          </dt>
+          <dd>
+            TODO: describe
+          </dd>
+        </dl>
+        <p>
+          A <a>depth map</a> has an associated <dfn>unit</dfn> which is a
+          DOMString. It represents the unit of the <a>depth map</a> and
+          associated <a>near value</a> and <a>far value</a>. It is one of the
+          following:
+        </p>
+        <dl>
+          <dt>
+            "<code><dfn>mm</dfn></code>"
+          </dt>
+          <dd>
+            Units represented in millimeters (mm).
+          </dd>
+          <dt>
+            "<code><dfn>m</dfn></code>"
+          </dt>
+          <dd>
+            Units represented in meters (m).
+          </dd>
+        </dl>
+        <p>
+          A <a>depth map</a> has an associated <dfn>near value</dfn> which is a
+          double. It represents the minimum range in <a>unit</a>s.
+        </p>
+        <p>
+          A <a>depth map</a> has an associated <dfn>far value</dfn> which is a
+          double. It represents the maximum range in <a>unit</a>s.
+        </p>
         <dl class="idl" title=
         " [Constructor(unsigned long sw, unsigned long sh), &nbsp;Constructor(Uint8ClampedArray data, unsigned long sw, optional unsigned long sh)] interface DepthMap">
         <dt>
@@ -496,13 +558,13 @@
             -
           </dd>
           <dt>
-            double format = null
+            DOMString format = null
           </dt>
           <dd>
             -
           </dd>
           <dt>
-            double units = null
+            DOMString unit = null
           </dt>
           <dd>
             -
@@ -521,24 +583,37 @@
           </dd>
         </dl>
         <p>
-          The <code id="widl-Settings-focalLength">focalLength</code> attribute
-          MUST return the value it was initialized to. When the object is
-          created, this attribute MUST be initialized to null. It represents
-          the focal length of the camera in millimeters.
+          The <code id="widl-Settings-focalLength">focalLength</code>
+          attribute's getter MUST return the <a>depth map</a>'s <a>focal
+          length</a>.
         </p>
         <p>
           The <code id=
           "widl-Settings-horizontalFieldOfView">horizontalFieldOfView</code>
-          attribute MUST return the value it was initialized to. When the
-          object is created, this attribute MUST be initialized to null. It
-          represents the horizontal angle of view in degrees.
+          attribute's getter MUST return the <a>depth map</a>'s <a>horizontal
+          field of view</a>.
         </p>
         <p>
           The <code id=
           "widl-Settings-verticalFieldOfView">verticalFieldOfView</code>
-          attribute MUST return the value it was initialized to. When the
-          object is created, this attribute MUST be initialized to null. It
-          represents the vertical angle of view in degrees.
+          attribute's getter MUST return the <a>depth map</a>'s <a>vertical
+          field of view</a>.
+        </p>
+        <p>
+          The <code id="widl-Settings-format">format</code> attribute's getter
+          MUST return the <a>depth map</a>'s <a>format</a>.
+        </p>
+        <p>
+          The <code id="widl-Settings-unit">unit</code> attribute's getter MUST
+          return the <a>depth map</a>'s <a>unit</a>.
+        </p>
+        <p>
+          The <code id="widl-Settings-near">near</code> attribute's getter MUST
+          return the <a>depth map</a>'s <a>near value</a>.
+        </p>
+        <p>
+          The <code id="widl-Settings-far">far</code> attribute's getter MUST
+          return the <a>depth map</a>'s <a>far value</a>.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
     </section>
     <section>
       <h2>
-        Terminology
+        Dependencies
       </h2>
       <p>
         The <code><a href=
@@ -196,6 +196,9 @@
         "https://people.mozilla.org/~jorendorff/es6-draft.html#sec-uint16array">
         <dfn>Uint16Array</dfn></a></code> types are defined in [[!ECMASCRIPT]].
       </p>
+    </section>
+    <section>
+      <h2>Terminology</h2>
       <p>
         A <dfn>depth stream</dfn> is a <code><a>MediaStream</a></code> object
         that contains one or more <a>depth track</a>s.

--- a/index.html
+++ b/index.html
@@ -84,48 +84,6 @@
     </section>
     <section id='sotd'>
       <p>
-        The following changes were made since the <a href=
-        "http://www.w3.org/TR/2014/WD-mediacapture-depth-20141007/">W3C First
-        Public Working Draft 07 October 2014</a>:
-      </p>
-      <ul>
-        <li>Removed the <a href=
-        "http://www.w3.org/TR/2014/WD-mediacapture-depth-20141007/#depthdata-interface">
-          <code>DepthData</code></a> interface
-        </li>
-        <li>Added depth value presentation into the <a href=
-        "#imagedata-interface"><code>ImageData</code></a> interface
-        </li>
-        <li>Added a <a>depth video element</a> as an image source in the
-        <a href="#canvasimagesource-typedef"><code>CanvasImageSource</code>
-        typedef</a>
-        </li>
-        <li>Added support for <a href=
-        "#direct-assignment-to-media-elements">direct assignment to media
-        elements</a> for <code><a>MediaStream</a></code> object containing a
-        <a>depth track</a>
-        </li>
-        <li>Added new properties to the <a><code>Settings</code></a> dictionary
-        </li>
-        <li>Added new definitions to the <a href="#terminology">terminology</a>
-        section
-        </li>
-        <li>Added a non-normative <a href=
-        "#implementation-considerations">implementation considerations</a>
-        section regarding combining a <a>depth track</a> and a <a>video
-        track</a> into one <code><a>MediaStream</a></code> object
-        </li>
-        <li>Added a non-normative <a href=
-        "#implementation-considerations-1">implementation considerations</a>
-        section considering the <a href=
-        "#webglrenderingcontext-interface"><code>WebGLRenderingContext</code></a>
-        interface
-        </li>
-        <li>Added <a href="#examples">examples</a> for 2D canvas context and
-        WebGL fragment shader based post-processing
-        </li>
-      </ul>
-      <p>
         <strong>This document is not complete and is subject to change. Early
         experimentations are encouraged to allow the Media Capture Task Force
         to evolve the specification based on technical discussions within the

--- a/index.html
+++ b/index.html
@@ -384,6 +384,43 @@
       </section>
       <section>
         <h2>
+          <code>FrameData</code> interface
+        </h2>
+        <dl class="idl" title="interface FrameData">
+          <dt>
+            readonly attribute DepthData? depthData
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute double? depthDataTimeStamp
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute ImageData? imageData
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute double? imageDataTimeStamp
+          </dt>
+          <dd>
+            -
+          </dd>
+          <dt>
+            readonly attribute double currentTime
+          </dt>
+          <dd>
+            -
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h2>
           <code>Settings</code> dictionary
         </h2>
         <p>

--- a/index.html
+++ b/index.html
@@ -544,6 +544,36 @@
         Examples
       </h2>
       <h3>
+        Capture individual depth and RGB frames
+      </h3>
+      <pre class='example highlight'>
+navigator.mediaDevices.getUserMedia({
+  depth: true,
+  video: true
+}).then(function (mediaStream) {
+  // mediaStream carries both video track and depth track
+  var frameGrabber = new FrameGrabber(mediaStream);
+  if (frameGrabber) {
+    frameGrabber.start(processDepthData);
+  }
+});
+
+function processDepthData(frameData) {
+ var w = frameData.depthData.width, h = frameData.depthData.height;
+ var pixels = frameData.imageData.data, dexels = frameData.depthData.data;
+ for (var x = 0; x &lt; w ; ++x) {
+   for (var y = 0; y &lt; h; ++y) {
+     var i = x + y * w;
+     var r = pixels[i*4];
+     var g = pixels[i*4 + 1];
+     var b = pixels[i*4 + 2];
+     var depth = dexels[i]; // Uint16 depth value
+   }
+ }
+}
+      
+</pre>
+      <h3>
         WebGL Fragment Shader based post-processing
       </h3>
       <pre class='example highlight'>

--- a/index.html
+++ b/index.html
@@ -316,7 +316,7 @@
       </section>
       <section>
         <h2>
-          <code>DepthData</code> interface
+          <code>DepthMap</code> interface
         </h2>
         <div class="note">
           <p>
@@ -328,10 +328,10 @@
           </p>
           <p>
             To address the issue, this specification defines a new
-            <code><a>DepthData</a></code> interface.
+            <code><a>DepthMap</a></code> interface.
           </p>
         </div>
-        <dl class="idl" title="interface DepthData">
+        <dl class="idl" title="interface DepthMap">
           <dt>
             readonly attribute unsigned long width
           </dt>
@@ -388,13 +388,13 @@
         </h2>
         <dl class="idl" title="interface FrameData">
           <dt>
-            readonly attribute DepthData? depthData
+            readonly attribute DepthMap? depthMap
           </dt>
           <dd>
             -
           </dd>
           <dt>
-            readonly attribute double? depthDataTimeStamp
+            readonly attribute double? depthMapTimeStamp
           </dt>
           <dd>
             -
@@ -554,13 +554,13 @@ navigator.mediaDevices.getUserMedia({
   // mediaStream carries both video track and depth track
   var frameGrabber = new FrameGrabber(mediaStream);
   if (frameGrabber) {
-    frameGrabber.start(processDepthData);
+    frameGrabber.start(processDepthMap);
   }
 });
 
-function processDepthData(frameData) {
- var w = frameData.depthData.width, h = frameData.depthData.height;
- var pixels = frameData.imageData.data, dexels = frameData.depthData.data;
+function processDepthMap(frameData) {
+ var w = frameData.depthMap.width, h = frameData.depthMap.height;
+ var pixels = frameData.imageData.data, dexels = frameData.depthMap.data;
  for (var x = 0; x &lt; w ; ++x) {
    for (var y = 0; y &lt; h; ++y) {
      var i = x + y * w;

--- a/index.html
+++ b/index.html
@@ -191,12 +191,10 @@
       </p>
       <p>
         The <code><a href=
-        "https://www.khronos.org/registry/typedarray/specs/latest/#5"><dfn>ArrayBuffer</dfn></a></code>,
-        <code><a href=
-        "http://www.khronos.org/registry/typedarray/specs/latest/#6"><dfn>ArrayBufferView</dfn></a></code>
-        and <code><a href=
-        "http://www.khronos.org/registry/typedarray/specs/latest/#7"><dfn>Uint16Array</dfn></a></code>
-        types are defined in [[!TYPEDARRAY]].
+        "https://people.mozilla.org/~jorendorff/es6-draft.html#sec-arraybuffer-objects">
+        <dfn>ArrayBuffer</dfn></a></code> and <code><a href=
+        "https://people.mozilla.org/~jorendorff/es6-draft.html#sec-uint16array">
+        <dfn>Uint16Array</dfn></a></code> types are defined in [[!ECMASCRIPT]].
       </p>
       <p>
         A <dfn>depth stream</dfn> is a <code><a>MediaStream</a></code> object
@@ -209,6 +207,13 @@
       <p>
         A <dfn>video track</dfn> represents media sourced from an RGB camera or
         other similar source.
+      </p>
+      <p>
+        A <dfn>depth map</dfn> is an image that contains information relating
+        to the distance of the surfaces of scene objects from a viewpoint.
+      </p>
+      <p>
+        A <dfn>dexel</dfn> is a depth pixel in the <a>depth map</a>.
       </p>
     </section>
     <section>
@@ -331,8 +336,9 @@
             <code><a>DepthMap</a></code> interface.
           </p>
         </div>
-        <dl class="idl" title="interface DepthMap">
-          <dt>
+        <dl class="idl" title=
+        " [Constructor(unsigned long sw, unsigned long sh), &nbsp;Constructor(Uint8ClampedArray data, unsigned long sw, optional unsigned long sh)] interface DepthMap">
+        <dt>
             readonly attribute unsigned long width
           </dt>
           <dd>
@@ -381,6 +387,52 @@
             -
           </dd>
         </dl>
+        <p>
+          New <code><a>DepthMap</a></code> objects MUST be initialized so that
+          their <code id="widl-DepthMap-width">width</code> attribute is set to
+          the number of <a title="dexel">dexels</a> per row in the <a>depth
+          map</a>, their <code id="widl-DepthMap-height">height</code>
+          attribute is set to the number of rows in the <a>depth map</a>, and
+          their <code id="widl-DepthMap-data">data</code> attribute is
+          initialized to a new <code><a>Uint16Array</a></code> object. The
+          <code><a>Uint16Array</a></code> object MUST use a new <a>Depth Map
+          <code>ArrayBuffer</code></a> for its storage, and must have a zero
+          start offset and a length equal to the length of its storage, in
+          bytes. The <a>Depth Map <code>ArrayBuffer</code></a> MUST contain the
+          <a>depth map</a>. At least one <a title="dexel">dexel's</a> worth of
+          <a>depth map</a> MUST be returned.
+        </p>
+        <p>
+          A <dfn>Depth Map <code>ArrayBuffer</code></dfn> is an
+          <code><a>ArrayBuffer</a></code> whose data is represented in
+          left-to-right order, row by row top to bottom, starting with the top
+          left, with each value representing a <a>dexel</a>, in that order.
+          Each <a>dexel</a> represented in this array MUST be in range
+          0..65535, representing the 16 bit value for that <a>dexel</a>. The
+          <a title="dexel">dexels</a> MUST be assigned consecutive indices
+          starting with 0 for the top left <a>dexel</a>.
+        </p>
+        <p>
+          The <dfn><code id=
+          "widl-DepthMap-measureType">measureType</code></dfn> attribute
+          represents the type of depth measurement. It can have the following
+          values:
+        </p>
+        <ul>
+          <li>
+            <dfn><code>opticalaxis</code></dfn>
+          </li>
+          <li>
+            <dfn><code>opticray</code></dfn>
+          </li>
+        </ul>
+        <p>
+          When the object is created, its <code><a>measureType</a></code> MUST
+          be set to string "<code><a>opticalaxis</a></code>", if the depth data
+          represents <a title="dexel">dexels</a> measured along the optical
+          axis, and to "<code><a>opticray</a></code>", if measured along the
+          optic ray.
+        </p>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -208,9 +208,6 @@
         A <dfn>video track</dfn> represents media sourced from an RGB camera or
         other similar source.
       </p>
-      <p>
-        A <dfn>dexel</dfn> is a depth pixel in the <a>depth map</a>.
-      </p>
     </section>
     <section>
       <h2>
@@ -238,6 +235,51 @@
           <a>depth track</a>. If a <a><code>Constraints</code></a> structure is
           provided, it further specifies the nature and settings of the
           <a>depth track</a>.
+        </p>
+      </section>
+      <section>
+        <h2>
+          <code><a>MediaTrackConstraints</a></code> dictionary
+        </h2>
+        <dl class="idl" title="partial dictionary MediaTrackConstraints">
+          <dt>
+            DepthMapUnit unit = "mm"
+          </dt>
+          <dd>
+            -
+          </dd>
+        </dl>
+        <dl id="enum-basic" class="idl" title="enum DepthMapUnit">
+          <dt>
+            mm
+          </dt>
+          <dd>
+            &nbsp;
+          </dd>
+          <dt>
+            m
+          </dt>
+          <dd>
+            &nbsp;
+          </dd>
+        </dl>
+        <p>
+          The <code id="widl-MediaTrackConstraints-unit">unit</code> attribute
+          MUST return the value it was initialized to. When the object is
+          created, it MUST have its <a>depth map unit</a> set to the string
+          "<code>mm</code>".
+        </p>
+        <p>
+          The <code><a>DepthMapUnit</a></code> enumeration is used to select
+          the <dfn>depth map unit</dfn> that applies to <a>dexel</a>s, <a>near
+          value</a>, and <a>far value</a> associated with a <a>depth map</a>.
+          The "<code>mm</code>" value indicates millimeters, the
+          "<code>m</code>" value indicates meters.
+        </p>
+        <p>
+          The <a>depth map unit</a> is said to be an <dfn>active depth map
+          unit</dfn> if a new <a>Depth Map <code>ArrayBuffer</code></a> has
+          been created.
         </p>
       </section>
       <section>
@@ -353,31 +395,17 @@
         </p>
         <p>
           A <a>depth map</a> has an associated <dfn>unit</dfn> which is a
-          DOMString. It represents the unit of the <a>depth map</a> and
-          associated <a>near value</a> and <a>far value</a>. It is one of the
-          following:
+          DOMString. It represents the <a>active depth map unit</a>.
         </p>
-        <dl>
-          <dt>
-            "<code><dfn>mm</dfn></code>"
-          </dt>
-          <dd>
-            Units represented in millimeters (mm).
-          </dd>
-          <dt>
-            "<code><dfn>m</dfn></code>"
-          </dt>
-          <dd>
-            Units represented in meters (m).
-          </dd>
-        </dl>
         <p>
           A <a>depth map</a> has an associated <dfn>near value</dfn> which is a
-          double. It represents the minimum range in <a>unit</a>s.
+          double. It represents the minimum range in <a>active depth map
+          unit</a>s.
         </p>
         <p>
           A <a>depth map</a> has an associated <dfn>far value</dfn> which is a
-          double. It represents the maximum range in <a>unit</a>s.
+          double. It represents the maximum range in <a>active depth map
+          unit</a>s.
         </p>
         <dl class="idl" title=
         " [Constructor(unsigned long sw, unsigned long sh), &nbsp;Constructor(Uint8ClampedArray data, unsigned long sw, optional unsigned long sh)] interface DepthMap">
@@ -419,11 +447,14 @@
           A <dfn>Depth Map <code>ArrayBuffer</code></dfn> is an
           <code><a>ArrayBuffer</a></code> whose data is represented in
           left-to-right order, row by row top to bottom, starting with the top
-          left, with each value representing a <a>dexel</a>, in that order.
+          left, with each value representing a <dfn>dexel</dfn>, in that order.
           Each <a>dexel</a> represented in this array MUST be in range
-          0..65535, representing the 16 bit value for that <a>dexel</a>. The
-          <a title="dexel">dexels</a> MUST be assigned consecutive indices
-          starting with 0 for the top left <a>dexel</a>.
+          0..65535, representing the 16 bit value for that <a>dexel</a> in
+          <a>depth map unit</a>s indicated by the <code><a href=
+          "#widl-MediaTrackConstraints-unit">unit</a></code> attribute of the
+          <a><code>MediaTrackConstraints</code></a> object. The <a title=
+          "dexel">dexels</a> MUST be assigned consecutive indices starting with
+          0 for the top left <a>dexel</a>.
         </p>
       </section>
       <section>
@@ -539,7 +570,7 @@
             -
           </dd>
           <dt>
-            DOMString unit = null
+            DepthMapUnit? unit = null
           </dt>
           <dd>
             -
@@ -576,7 +607,7 @@
         </p>
         <p>
           The <code id="widl-Settings-unit">unit</code> attribute's getter MUST
-          return the <a>depth map</a>'s <a>unit</a>.
+          return the <a>active depth map unit</a>.
         </p>
         <p>
           The <code id="widl-Settings-near">near</code> attribute's getter MUST

--- a/index.html
+++ b/index.html
@@ -352,25 +352,6 @@
           view in degrees.
         </p>
         <p>
-          A <a>depth map</a> has an associated <dfn>format</dfn> which is a
-          DOMString. It represents the format of the <a>depth map</a>, and is
-          one of the following:
-        </p>
-        <dl>
-          <dt>
-            "<code><dfn>linear</dfn></code>"
-          </dt>
-          <dd>
-            TODO: describe
-          </dd>
-          <dt>
-            "<code><dfn>inverse</dfn></code>"
-          </dt>
-          <dd>
-            TODO: describe
-          </dd>
-        </dl>
-        <p>
           A <a>depth map</a> has an associated <dfn>unit</dfn> which is a
           DOMString. It represents the unit of the <a>depth map</a> and
           associated <a>near value</a> and <a>far value</a>. It is one of the
@@ -558,12 +539,6 @@
             -
           </dd>
           <dt>
-            DOMString format = null
-          </dt>
-          <dd>
-            -
-          </dd>
-          <dt>
             DOMString unit = null
           </dt>
           <dd>
@@ -598,10 +573,6 @@
           "widl-Settings-verticalFieldOfView">verticalFieldOfView</code>
           attribute's getter MUST return the <a>depth map</a>'s <a>vertical
           field of view</a>.
-        </p>
-        <p>
-          The <code id="widl-Settings-format">format</code> attribute's getter
-          MUST return the <a>depth map</a>'s <a>format</a>.
         </p>
         <p>
           The <code id="widl-Settings-unit">unit</code> attribute's getter MUST

--- a/index.html
+++ b/index.html
@@ -554,11 +554,11 @@ navigator.mediaDevices.getUserMedia({
   // mediaStream carries both video track and depth track
   var frameGrabber = new FrameGrabber(mediaStream);
   if (frameGrabber) {
-    frameGrabber.start(processDepthMap);
+    frameGrabber.start(processFrameData);
   }
 });
 
-function processDepthMap(frameData) {
+function processFrameData(frameData) {
  var w = frameData.depthMap.width, h = frameData.depthMap.height;
  var pixels = frameData.imageData.data, dexels = frameData.depthMap.data;
  for (var x = 0; x &lt; w ; ++x) {

--- a/index.html
+++ b/index.html
@@ -112,13 +112,13 @@
         extends the <code><a>MediaStream</a></code> interface [[!GETUSERMEDIA]]
         to enable it to also contain depth-based
         <a><code>MediaStreamTrack</code></a>s. A depth-based
-        <a><code>MediaStreamTrack</code></a>, referred to as a <a>depth
+        <a><code>MediaStreamTrack</code></a>, referred to as a <a>depth stream
         track</a>, represents an abstraction of a stream of frames that can
         each be converted to objects which contain an array of pixel data,
         where each pixel represents the distance between the camera and the
         objects in the scene for that point in the array. A
         <code><a>MediaStream</a></code> object that contains one or more
-        <a>depth track</a>s is referred to as a <a>depth stream</a>.
+        <a>depth stream track</a>s is referred to as a <a>depth stream</a>.
       </p>
     </section>
     <section>
@@ -198,18 +198,23 @@
       </p>
     </section>
     <section>
-      <h2>Terminology</h2>
+      <h2>
+        Terminology
+      </h2>
       <p>
-        A <dfn>depth stream</dfn> is a <code><a>MediaStream</a></code> object
-        that contains one or more <a>depth track</a>s.
+        The term <dfn>depth stream</dfn> means a
+        <code><a>MediaStream</a></code> object that contains one or more
+        <a>depth stream track</a>s.
       </p>
       <p>
-        A <dfn>depth track</dfn> represents media sourced from a depth camera
-        or other similar source.
+        The term <dfn>depth stream track</dfn> means a
+        <code><a>MediaStreamTrack</a></code> object that represents media
+        sourced from a depth camera.
       </p>
       <p>
-        A <dfn>video track</dfn> represents media sourced from an RGB camera or
-        other similar source.
+        The term <dfn>video stream track</dfn> means a
+        <code><a>MediaStreamTrack</a></code> object that represents media
+        sourced from an RGB camera.
       </p>
     </section>
     <section>
@@ -235,9 +240,9 @@
           true, the attribute represents a request that the
           <code><a>MediaStream</a></code> object returned as an argument of the
           <code><a>NavigatorUserMediaSuccessCallback</a></code> contains a
-          <a>depth track</a>. If a <a><code>Constraints</code></a> structure is
-          provided, it further specifies the nature and settings of the
-          <a>depth track</a>.
+          <a>depth stream track</a>. If a <a><code>Constraints</code></a>
+          structure is provided, it further specifies the nature and settings
+          of the <a>depth stream track</a>.
         </p>
       </section>
       <section>
@@ -300,9 +305,8 @@
         <p>
           The <code id=
           "widl-MediaStream-getDepthTracks-sequence-MediaStreamTrack"><dfn>getDepthTracks()</dfn></code>
-          method, when invoked, MUST return a sequence of
-          <a><code>MediaStreamTrack</code></a> objects representing the
-          <a>depth track</a>s in this stream.
+          method, when invoked, MUST return a sequence of <a>depth stream
+          track</a>s in this stream.
         </p>
         <p>
           The <code><a>getDepthTracks()</a></code> method MUST return a
@@ -318,10 +322,8 @@
             Implementation considerations
           </h3>
           <p>
-            A <a><code>MediaStreamTrack</code></a> object representing a
-            <a>video track</a> and a <a><code>MediaStreamTrack</code></a>
-            object representing a <a>depth track</a> can be combined into one
-            <code><a>MediaStream</a></code> object. The rendering of the two
+            A <a>video stream track</a> and a <a>depth stream track</a> can be
+            combined into one <a>depth stream</a>. The rendering of the two
             tracks are intended to be synchronized. The resolution of the two
             tracks are intended to be same. And the coordination of the two
             tracks are intended to be calibrated. These are not hard
@@ -337,7 +339,7 @@
         <p>
           The <code><dfn>kind</dfn></code> attribute MUST, on getting, return
           the string "<code>depth</code>" if the object represents a <a>depth
-          track</a>.
+          stream track</a>.
         </p>
       </section>
       <section>
@@ -348,14 +350,12 @@
           <a>User agent</a>s that support <code><a>MediaStream</a></code>
           <a href=
           "http://w3c.github.io/mediacapture-main/getusermedia.html#direct-assignment-to-media-elements">
-          direct assignment to media elements</a> MUST allow a
-          <code><a>MediaStream</a></code> object containing a <a>depth
-          track</a> to be assigned directly to a media element.
+          direct assignment to media elements</a> MUST allow a <a>depth
+          stream</a> to be assigned directly to a media element.
         </p>
         <p>
-          For each <a><code>MediaStreamTrack</code></a> representing a <a>depth
-          track</a> in the <code><a>MediaStream</a></code>, the <a>user
-          agent</a> MUST create a corresponding <code><a href=
+          For each <a>depth stream track</a> in the <a>depth stream</a>, the
+          <a>user agent</a> MUST create a corresponding <code><a href=
           "http://www.w3.org/TR/html5/embedded-content-0.html#videotrack">VideoTrack</a></code>
           as defined in [[HTML5]].
         </p>
@@ -543,9 +543,8 @@
           <code>MediaTrackSettings</code> dictionary
         </h2>
         <p>
-          When the <code>getSettings()</code> method is invoked on a
-          <a><code>MediaStreamTrack</code></a> object that represents a
-          <a>depth track</a>, the <a>user agent</a> MUST return the following
+          When the <code>getSettings()</code> method is invoked on a <a>depth
+          stream track</a>, the <a>user agent</a> MUST return the following
           dictionary that extends the <a><code>MediaTrackSettings</code></a>
           dictionary:
         </p>
@@ -627,7 +626,7 @@
           </h3>
           <p>
             A <code>video</code> element whose source is a
-            <code><a>MediaStream</a></code> object containing a <a>depth
+            <code><a>MediaStream</a></code> object containing a <a>depth stream
             track</a> may be uploaded to a WebGL texture of format
             <code>RGB</code> and type <code>UNSIGNED_BYTE</code>. [[WEBGL]]
           </p>
@@ -652,7 +651,7 @@ navigator.mediaDevices.getUserMedia({
   depth: true,
   video: true
 }).then(function (mediaStream) {
-  // mediaStream carries both video track and depth track
+  // mediaStream carries both video stream track and depth stream track
   var frameGrabber = new FrameGrabber(mediaStream);
   if (frameGrabber) {
     frameGrabber.start(processFrameData);


### PR DESCRIPTION
This PR contains an early proposal with contributions from @huningxin @ds-hwang @robman and @anssiko. IDL is in place to allow people to review the API shape, but the prose around the new interfaces is still missing to allow us more easily iterate on the API design based on wider feedback.

HTML preview: https://rawgit.com/anssiko/mediacapture-depth/framegrabber/index.html

New interfaces added in this PR:
- `FrameGrabber`
- `FrameData`
- `DepthData`

The following interfaces and definitions were obsoleted by the new ones, and were removed:
- `CanvasImageSource typedef`
- `ImageData interface` (or to be precise, extensions to it)

Examples:
- Added a new example 'Capture individual depth and RGB frames'; removed the obsoleted '2D Canvas Context based post-processing' example.

Editorial:
- Removed the changes since the last publication from the Status of This Document section. Not needed for an Editor's Draft.
