### PR TITLE
Fix #114: Add depthNear and depthFar constrainable properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -492,8 +492,6 @@
           given a depth map value <var>d</var>, is as follows:
         </p>
         <ol>
-          <li>Let <var>bit depth</var> be the bit depth of the depth map.
-          </li>
           <li>Let <var>near</var> be the the <a>near value</a>.
           </li>
           <li>Let <var>far</var> be the the <a>far value</a>.

--- a/index.html
+++ b/index.html
@@ -224,8 +224,6 @@
         The <code><a href=
         "https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia">
         <dfn>getUserMedia()</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/#dfn-applyconstraints"><dfn>applyConstraints()</dfn></a></code>,
-        <code><a href=
         "https://w3c.github.io/mediacapture-main/#dfn-getsettings"><dfn>getSettings()</dfn></a></code>
         methods and the <code><a href=
         "https://w3c.github.io/mediacapture-main/#idl-def-NavigatorUserMediaSuccessCallback">
@@ -635,11 +633,6 @@
             </tr>
           </tbody>
         </table>
-        <p>
-          The <a>applyConstraints()</a> method MUST reject the promise with
-          <code>OverconstrainedError</code>, when invoked with
-          <code>depthNear</code> or <code>depthFar</code> property.
-        </p>
         <pre class="idl">
           partial dictionary MediaTrackConstraintSet {
             ConstrainDouble depthNear;

--- a/index.html
+++ b/index.html
@@ -321,11 +321,11 @@
         </p>
         <p>
           A <a>depth map</a> has an associated <dfn>near value</dfn> which is a
-          double. It represents the minimum range in millimeters.
+          double. It represents the minimum range in meters.
         </p>
         <p>
           A <a>depth map</a> has an associated <dfn>far value</dfn> which is a
-          double. It represents the maximum range in millimeters.
+          double. It represents the maximum range in meters.
         </p>
       </section>
     </section>
@@ -512,9 +512,9 @@
         <img src="images/quantization.png" alt="d_(8bit) = floor(d_(n) * 255)">
         <div class="note">
           <p>
-            The depth measurement <var>d</var> (in millimeter units) is
-            recovered by solving the <a>rules to convert using range
-            inverse</a> for <var>d</var> as follows:
+            The depth measurement <var>d</var> (in meter units) is recovered by
+            solving the <a>rules to convert using range inverse</a> for
+            <var>d</var> as follows:
           </p>
           <ol>
             <li>Given <var>d<sub>8bit</sub></var>, <var>near</var> <a>near
@@ -580,6 +580,85 @@
             the <a>depth map</a>'s <a>far value</a>.
           </p>
         </div>
+      </section>
+      <section>
+        <h2>
+          Constrainable properties
+        </h2>
+        <p>
+          The <code>depthNear</code> and <code>depthFar</code> constrainable
+          properties are defined to apply only to <a>depth stream track</a>s.
+        </p>
+        <div class="note">
+          The <code>depthNear</code> and <code>depthFar</code> constrainable
+          properties, when set, allow the implementation to pick the best depth
+          camera mode optimized for the range <code>[depthNear,
+          depthFar]</code> and help minimize the error introduced by the lossy
+          conversion from the depth value <var>d</var> to a quantized
+          d<sub>8bit</sub> and back to an approximation of the depth value
+          <var>d</var>.
+        </div>
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>
+                Property name
+              </th>
+              <th>
+                Values
+              </th>
+              <th>
+                Notes
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code>depthNear</code>
+              </td>
+              <td>
+                <code>ConstrainDouble</code>
+              </td>
+              <td>
+                The <a>near value</a>, in meters.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>depthFar</code>
+              </td>
+              <td>
+                <code>ConstrainDouble</code>
+              </td>
+              <td>
+                The <a>far value</a>, in meters.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          The <a>applyConstraints()</a> method MUST reject the promise with
+          <code>OverconstrainedError</code>, when invoked with
+          <code>depthNear</code> or <code>depthFar</code> property.
+        </p>
+        <pre class="idl">
+          partial dictionary MediaTrackConstraintSet {
+            ConstrainDouble depthNear;
+            ConstrainDouble depthFar;
+          };
+        </pre>
+        <pre class="idl">
+          partial dictionary MediaTrackSupportedConstraints {
+            boolean depthNear = true;
+            boolean depthFar = true;
+          };
+
+          partial dictionary MediaTrackCapabilities {
+            ConstrainDouble depthNear;
+            ConstrainDouble depthFar;
+          };
+        </pre>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -196,27 +196,27 @@
       </h2>
       <p>
         The <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#idl-def-MediaStreamTrack">
+        "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#idl-def-MediaStreamTrack">
         <dfn>MediaStreamTrack</dfn></a></code> and <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#idl-def-MediaStream">
+        "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#idl-def-MediaStream">
         <dfn>MediaStream</dfn></a></code> interfaces this specification extends
         are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
         The <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#idl-def-Constraints">
+        "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#idl-def-Constraints">
         <dfn>Constraints</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#idl-def-MediaStreamConstraints">
+        "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#idl-def-MediaStreamConstraints">
         <dfn>MediaStreamConstraints</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#idl-def-MediaTrackSettings">
+        "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#idl-def-MediaTrackSettings">
         <dfn>MediaTrackSettings</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#idl-def-MediaTrackConstraints">
+        "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#idl-def-MediaTrackConstraints">
         <dfn>MediaTrackConstraints</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#idl-def-MediaTrackSupportedConstraints">
+        "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#idl-def-MediaTrackSupportedConstraints">
         <dfn>MediaTrackSupportedConstraints</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#idl-def-MediaTrackCapabilities">
+        "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#idl-def-MediaTrackCapabilities">
         <dfn>MediaTrackCapabilities</dfn></a></code>, and <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#idl-def-MediaTrackConstraintSet">
+        "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#idl-def-MediaTrackConstraintSet">
         <dfn>MediaTrackConstraintSet</dfn></a></code> dictionaries this
         specification extends are defined in [[!GETUSERMEDIA]].
       </p>
@@ -236,7 +236,7 @@
         <a href=
         "https://w3c.github.io/mediacapture-main/#track-enabled"><dfn>disabled</dfn></a>,
         and <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#event-mediastreamtrack-overconstrained">
+        "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#event-mediastreamtrack-overconstrained">
         <dfn>overconstrained</dfn></a></code> as applied to
         <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
       </p>

--- a/index.html
+++ b/index.html
@@ -232,10 +232,13 @@
       </p>
       <p>
         The concepts <a href=
-        "https://w3c.github.io/mediacapture-main/#track-muted"><dfn>muted</dfn></a>
-        and <a href=
-        "https://w3c.github.io/mediacapture-main/#track-enabled"><dfn>disabled</dfn></a>
-        as applied to <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
+        "https://w3c.github.io/mediacapture-main/#track-muted"><dfn>muted</dfn></a>,
+        <a href=
+        "https://w3c.github.io/mediacapture-main/#track-enabled"><dfn>disabled</dfn></a>,
+        and <code><a href=
+        "https://w3c.github.io/mediacapture-main/archives/20160222/getusermedia.html#event-mediastreamtrack-overconstrained">
+        <dfn>overconstrained</dfn></a></code> as applied to
+        <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
         The terms <a href=
@@ -633,6 +636,11 @@
             </tr>
           </tbody>
         </table>
+        <p>
+          If the <code>depthFar</code> property's value is less than the
+          <code>depthNear</code> property's value, the <a>depth stream
+          track</a> is <a>overconstrained</a>.
+        </p>
         <pre class="idl">
           partial dictionary MediaTrackConstraintSet {
             ConstrainDouble depthNear;


### PR DESCRIPTION
As a fix to #114 this PR adds `depthNear` and `depthFar` constrainable properties. Note we switch to use meter as the unit (from millimeters) for the near value and far value as suggested by @martinthomson, and also the recovered depth measurement `d` is now reported in meters for consistency.

I have one question for the group:
- Do we want to special case `depthFar < depthNear`, or leave it to the implementation to figure out what to do in such a case?

Seeking review from @huningxin @martinthomson @jan-ivar @alvestrand et al.
