### PR TITLE
Fix #102: Define non-constrainable property

### DIFF
--- a/index.html
+++ b/index.html
@@ -692,12 +692,6 @@
           lens may be fixed, or the underlying platform may not expose the
           focal length information.)
         </p>
-        <p>
-          If the <a>near value</a>, <a>far value</a>, <a>focal length</a>,
-          <a>horizontal field of view</a>, or <a>vertical field of view</a> is
-          unknown due to any reason, the corresponding constrainable property's
-          value MUST be set to the value 0.
-        </p>
         <pre class="idl">
           partial dictionary MediaTrackConstraintSet {
             ConstrainDouble depthNear;

--- a/index.html
+++ b/index.html
@@ -224,8 +224,6 @@
         The <code><a href=
         "https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia">
         <dfn>getUserMedia()</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/#dfn-applyconstraints"><dfn>applyConstraints()</dfn></a></code>,
-        <code><a href=
         "https://w3c.github.io/mediacapture-main/#dfn-getsettings"><dfn>getSettings()</dfn></a></code>
         methods and the <code><a href=
         "https://w3c.github.io/mediacapture-main/#idl-def-NavigatorUserMediaSuccessCallback">
@@ -240,9 +238,7 @@
         and <code><a href=
         "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#event-mediastreamtrack-overconstrained">
         <dfn>overconstrained</dfn></a></code> as applied to
-        <a>MediaStreamTrack</a> as well as the concept <a href=
-        "https://w3c.github.io/mediacapture-main/#dfn-fitness-distance"><dfn>fitness
-        distance</dfn></a> are defined in [[!GETUSERMEDIA]].
+        <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
         The terms <a href=
@@ -564,18 +560,15 @@
         <div dfn-for="MediaTrackSettings">
           <p>
             The <dfn><code>focalLength</code></dfn> dictionary member
-            represents the <a>depth map</a>'s <a>focal length</a>. It is a
-            <a>non-constrainable property</a>.
+            represents the <a>depth map</a>'s <a>focal length</a>.
           </p>
           <p>
             The <dfn><code>horizontalFieldOfView</code></dfn> dictionary member
             represents the <a>depth map</a>'s <a>horizontal field of view</a>.
-            It is a <a>non-constrainable property</a>.
           </p>
           <p>
             The <dfn><code>verticalFieldOfView</code></dfn> dictionary member
-            represents the <a>depth map</a>'s <a>vertical field of view</a>. It
-            is a <a>non-constrainable property</a>.
+            represents the <a>depth map</a>'s <a>vertical field of view</a>.
           </p>
           <p>
             The <dfn><code>depthNear</code></dfn> dictionary member represents
@@ -665,33 +658,6 @@
             ConstrainDouble depthFar;
           };
         </pre>
-      </section>
-      <section>
-        <h2>
-          Non-constrainable properties
-        </h2>
-        <p>
-          A <dfn lt=
-          "non-constrainable property|non-constrainable properties">non-constrainable
-          property</dfn> is ignored in the context of the
-          <a>applyConstraints()</a> algorithm. Its value can be obtained via
-          the <a>getSettings()</a> accessor. A <a>non-constrainable
-          property</a>'s <a>fitness distance</a> is always 0.
-        </p>
-        <p>
-          The following are the <a>non-constrainable properties</a>:
-        </p>
-        <ul link-for="MediaTrackSettings">
-          <li>
-            <a>focalLength</a>
-          </li>
-          <li>
-            <a>horizontalFieldOfView</a>
-          </li>
-          <li>
-            <a>verticalFieldOfView</a>
-          </li>
-        </ul>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -550,8 +550,8 @@
         </p>
         <pre class="idl">
           partial dictionary MediaTrackSettings {
-              double              depthNear;
-              double              depthFar;
+              double              near;
+              double              far;
               double              focalLength;
               double              horizontalFieldOfView;
               double              verticalFieldOfView;
@@ -559,12 +559,12 @@
         </pre>
         <div dfn-for="MediaTrackSettings">
           <p>
-            The <dfn><code>depthNear</code></dfn> dictionary member represents
-            the <a>depth map</a>'s <a>near value</a>.
+            The <dfn><code>near</code></dfn> dictionary member represents the
+            <a>depth map</a>'s <a>near value</a>.
           </p>
           <p>
-            The <dfn><code>depthFar</code></dfn> dictionary member represents
-            the <a>depth map</a>'s <a>far value</a>.
+            The <dfn><code>far</code></dfn> dictionary member represents the
+            <a>depth map</a>'s <a>far value</a>.
           </p>
           <p>
             The <dfn><code>focalLength</code></dfn> dictionary member
@@ -601,7 +601,7 @@
           <tbody>
             <tr>
               <td>
-                <code>depthNear</code>
+                <code>near</code>
               </td>
               <td>
                 <code>ConstrainDouble</code>
@@ -612,7 +612,7 @@
             </tr>
             <tr>
               <td>
-                <code>depthFar</code>
+                <code>far</code>
               </td>
               <td>
                 <code>ConstrainDouble</code>
@@ -657,8 +657,8 @@
           </tbody>
         </table>
         <p>
-          The <code>depthNear</code>, <code>depthFar</code>,
-          <code>focalLength</code>, <code>horizontalFieldOfView</code>, and
+          The <code>near</code>, <code>far</code>, <code>focalLength</code>,
+          <code>horizontalFieldOfView</code>, and
           <code>verticalFieldOfView</code> constrainable properties are defined
           to apply only to <a>depth stream track</a>s.
         </p>
@@ -670,18 +670,17 @@
           <a>MediaStreamTrack</a> objects as well.
         </div>
         <p>
-          The <code>depthNear</code> and <code>depthFar</code> constrainable
-          properties, when set, allow the implementation to pick the best depth
-          camera mode optimized for the range <code>[depthNear,
-          depthFar]</code> and help minimize the error introduced by the lossy
-          conversion from the depth value <var>d</var> to a quantized
-          d<sub>8bit</sub> and back to an approximation of the depth value
-          <var>d</var>.
+          The <code>near</code> and <code>far</code> constrainable properties,
+          when set, allow the implementation to pick the best depth camera mode
+          optimized for the range <code>[near, far]</code> and help minimize
+          the error introduced by the lossy conversion from the depth value
+          <var>d</var> to a quantized d<sub>8bit</sub> and back to an
+          approximation of the depth value <var>d</var>.
         </p>
         <p>
-          If the <code>depthFar</code> property's value is less than the
-          <code>depthNear</code> property's value, the <a>depth stream
-          track</a> is <a>overconstrained</a>.
+          If the <code>far</code> property's value is less than the
+          <code>near</code> property's value, the <a>depth stream track</a> is
+          <a>overconstrained</a>.
         </p>
         <p>
           If the <a>near value</a>, <a>far value</a>, <a>focal length</a>,
@@ -694,24 +693,24 @@
         </p>
         <pre class="idl">
           partial dictionary MediaTrackConstraintSet {
-            ConstrainDouble depthNear;
-            ConstrainDouble depthFar;
+            ConstrainDouble near;
+            ConstrainDouble far;
             ConstrainDouble focalLength;
             ConstrainDouble horizontalFieldOfView;
             ConstrainDouble verticalFieldOfView;
           };
 
           partial dictionary MediaTrackSupportedConstraints {
-            boolean depthNear = true;
-            boolean depthFar = true;
+            boolean near = true;
+            boolean far = true;
             boolean focalLength = true;
             boolean horizontalFieldOfView = true;
             boolean verticalFieldOfView = true;
           };
 
           partial dictionary MediaTrackCapabilities {
-            (double or DoubleRange) depthNear;
-            (double or DoubleRange) depthFar;
+            (double or DoubleRange) near;
+            (double or DoubleRange) far;
             (double or DoubleRange) focalLength;
             (double or DoubleRange) horizontalFieldOfView;
             (double or DoubleRange) verticalFieldOfView;

--- a/index.html
+++ b/index.html
@@ -306,6 +306,14 @@
           scene objects from a viewpoint.
         </p>
         <p>
+          A <a>depth map</a> has an associated <dfn>near value</dfn> which is a
+          double. It represents the minimum range in meters.
+        </p>
+        <p>
+          A <a>depth map</a> has an associated <dfn>far value</dfn> which is a
+          double. It represents the maximum range in meters.
+        </p>
+        <p>
           A <a>depth map</a> has an associated <dfn>focal length</dfn> which is
           a double. It represents the focal length of the camera in
           millimeters.
@@ -319,14 +327,6 @@
           A <a>depth map</a> has an associated <dfn>vertical field of
           view</dfn> which is a double. It represents the vertical angle of
           view in degrees.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>near value</dfn> which is a
-          double. It represents the minimum range in meters.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>far value</dfn> which is a
-          double. It represents the maximum range in meters.
         </p>
       </section>
     </section>
@@ -550,14 +550,22 @@
         </p>
         <pre class="idl">
           partial dictionary MediaTrackSettings {
+              double              depthNear;
+              double              depthFar;
               double              focalLength;
               double              horizontalFieldOfView;
               double              verticalFieldOfView;
-              double              depthNear;
-              double              depthFar;
           };
         </pre>
         <div dfn-for="MediaTrackSettings">
+          <p>
+            The <dfn><code>depthNear</code></dfn> dictionary member represents
+            the <a>depth map</a>'s <a>near value</a>.
+          </p>
+          <p>
+            The <dfn><code>depthFar</code></dfn> dictionary member represents
+            the <a>depth map</a>'s <a>far value</a>.
+          </p>
           <p>
             The <dfn><code>focalLength</code></dfn> dictionary member
             represents the <a>depth map</a>'s <a>focal length</a>.
@@ -570,33 +578,12 @@
             The <dfn><code>verticalFieldOfView</code></dfn> dictionary member
             represents the <a>depth map</a>'s <a>vertical field of view</a>.
           </p>
-          <p>
-            The <dfn><code>depthNear</code></dfn> dictionary member represents
-            the <a>depth map</a>'s <a>near value</a>.
-          </p>
-          <p>
-            The <dfn><code>depthFar</code></dfn> dictionary member represents
-            the <a>depth map</a>'s <a>far value</a>.
-          </p>
         </div>
       </section>
       <section>
         <h2>
           Constrainable properties
         </h2>
-        <p>
-          The <code>depthNear</code> and <code>depthFar</code> constrainable
-          properties are defined to apply only to <a>depth stream track</a>s.
-        </p>
-        <div class="note">
-          The <code>depthNear</code> and <code>depthFar</code> constrainable
-          properties, when set, allow the implementation to pick the best depth
-          camera mode optimized for the range <code>[depthNear,
-          depthFar]</code> and help minimize the error introduced by the lossy
-          conversion from the depth value <var>d</var> to a quantized
-          d<sub>8bit</sub> and back to an approximation of the depth value
-          <var>d</var>.
-        </div>
         <table class="simple">
           <thead>
             <tr>
@@ -634,28 +621,106 @@
                 The <a>far value</a>, in meters.
               </td>
             </tr>
+            <tr>
+              <td>
+                <code>focalLength</code>
+              </td>
+              <td>
+                <code>ConstrainDouble</code>
+              </td>
+              <td>
+                The <a>focal length</a>, in millimeters.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>horizontalFieldOfView</code>
+              </td>
+              <td>
+                <code>ConstrainDouble</code>
+              </td>
+              <td>
+                The <a>horizontal field of view</a>, in degrees.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>verticalFieldOfView</code>
+              </td>
+              <td>
+                <code>ConstrainDouble</code>
+              </td>
+              <td>
+                The <a>vertical field of view</a>, in degrees.
+              </td>
+            </tr>
           </tbody>
         </table>
+        <p>
+          The <code>depthNear</code>, <code>depthFar</code>,
+          <code>focalLength</code>, <code>horizontalFieldOfView</code>, and
+          <code>verticalFieldOfView</code> constrainable properties are defined
+          to apply only to <a>depth stream track</a>s.
+        </p>
+        <div class="note">
+          The <code>focalLength</code>, <code>horizontalFieldOfView</code>, and
+          <code>verticalFieldOfView</code> properties could be upstreamed to a
+          future version of the the <em>Media Capture and Streams</em>
+          specification [[!GETUSERMEDIA]] to allow them to be applied to video
+          <a>MediaStreamTrack</a> objects as well.
+        </div>
+        <p>
+          The <code>depthNear</code> and <code>depthFar</code> constrainable
+          properties, when set, allow the implementation to pick the best depth
+          camera mode optimized for the range <code>[depthNear,
+          depthFar]</code> and help minimize the error introduced by the lossy
+          conversion from the depth value <var>d</var> to a quantized
+          d<sub>8bit</sub> and back to an approximation of the depth value
+          <var>d</var>.
+        </p>
         <p>
           If the <code>depthFar</code> property's value is less than the
           <code>depthNear</code> property's value, the <a>depth stream
           track</a> is <a>overconstrained</a>.
         </p>
+        <p>
+          If the <a>near value</a>, <a>far value</a>, <a>focal length</a>,
+          <a>horizontal field of view</a>, or <a>vertical field of view</a> is
+          fixed due to a hardware or software limitation, the corresponding
+          constrainable property's value MUST be set to the value reported by
+          the underlying implementation. (For example, the focal length of the
+          lens may be fixed, or the underlying platform may not expose the
+          focal length information.)
+        </p>
+        <p>
+          If the <a>near value</a>, <a>far value</a>, <a>focal length</a>,
+          <a>horizontal field of view</a>, or <a>vertical field of view</a> is
+          unknown due to any reason, the corresponding constrainable property's
+          value MUST be set to the value 0.
+        </p>
         <pre class="idl">
           partial dictionary MediaTrackConstraintSet {
             ConstrainDouble depthNear;
             ConstrainDouble depthFar;
+            ConstrainDouble focalLength;
+            ConstrainDouble horizontalFieldOfView;
+            ConstrainDouble verticalFieldOfView;
           };
-        </pre>
-        <pre class="idl">
+
           partial dictionary MediaTrackSupportedConstraints {
             boolean depthNear = true;
             boolean depthFar = true;
+            boolean focalLength = true;
+            boolean horizontalFieldOfView = true;
+            boolean verticalFieldOfView = true;
           };
 
           partial dictionary MediaTrackCapabilities {
-            ConstrainDouble depthNear;
-            ConstrainDouble depthFar;
+            double depthNear;
+            double depthFar;
+            double focalLength;
+            double horizontalFieldOfView;
+            double verticalFieldOfView;
           };
         </pre>
       </section>

--- a/index.html
+++ b/index.html
@@ -224,6 +224,8 @@
         The <code><a href=
         "https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia">
         <dfn>getUserMedia()</dfn></a></code>, <code><a href=
+        "https://w3c.github.io/mediacapture-main/#dfn-applyconstraints"><dfn>applyConstraints()</dfn></a></code>,
+        <code><a href=
         "https://w3c.github.io/mediacapture-main/#dfn-getsettings"><dfn>getSettings()</dfn></a></code>
         methods and the <code><a href=
         "https://w3c.github.io/mediacapture-main/#idl-def-NavigatorUserMediaSuccessCallback">
@@ -238,7 +240,9 @@
         and <code><a href=
         "https://w3c.github.io/mediacapture-main/archives/20160406/getusermedia.html#event-mediastreamtrack-overconstrained">
         <dfn>overconstrained</dfn></a></code> as applied to
-        <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
+        <a>MediaStreamTrack</a> as well as the concept <a href=
+        "https://w3c.github.io/mediacapture-main/#dfn-fitness-distance"><dfn>fitness
+        distance</dfn></a> are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
         The terms <a href=
@@ -560,15 +564,18 @@
         <div dfn-for="MediaTrackSettings">
           <p>
             The <dfn><code>focalLength</code></dfn> dictionary member
-            represents the <a>depth map</a>'s <a>focal length</a>.
+            represents the <a>depth map</a>'s <a>focal length</a>. It is a
+            <a>non-constrainable property</a>.
           </p>
           <p>
             The <dfn><code>horizontalFieldOfView</code></dfn> dictionary member
             represents the <a>depth map</a>'s <a>horizontal field of view</a>.
+            It is a <a>non-constrainable property</a>.
           </p>
           <p>
             The <dfn><code>verticalFieldOfView</code></dfn> dictionary member
-            represents the <a>depth map</a>'s <a>vertical field of view</a>.
+            represents the <a>depth map</a>'s <a>vertical field of view</a>. It
+            is a <a>non-constrainable property</a>.
           </p>
           <p>
             The <dfn><code>depthNear</code></dfn> dictionary member represents
@@ -658,6 +665,33 @@
             ConstrainDouble depthFar;
           };
         </pre>
+      </section>
+      <section>
+        <h2>
+          Non-constrainable properties
+        </h2>
+        <p>
+          A <dfn lt=
+          "non-constrainable property|non-constrainable properties">non-constrainable
+          property</dfn> is ignored in the context of the
+          <a>applyConstraints()</a> algorithm. Its value can be obtained via
+          the <a>getSettings()</a> accessor. A <a>non-constrainable
+          property</a>'s <a>fitness distance</a> is always 0.
+        </p>
+        <p>
+          The following are the <a>non-constrainable properties</a>:
+        </p>
+        <ul link-for="MediaTrackSettings">
+          <li>
+            <a>focalLength</a>
+          </li>
+          <li>
+            <a>horizontalFieldOfView</a>
+          </li>
+          <li>
+            <a>verticalFieldOfView</a>
+          </li>
+        </ul>
       </section>
       <section>
         <h2>

--- a/index.html
+++ b/index.html
@@ -710,11 +710,11 @@
           };
 
           partial dictionary MediaTrackCapabilities {
-            double depthNear;
-            double depthFar;
-            double focalLength;
-            double horizontalFieldOfView;
-            double verticalFieldOfView;
+            (double or DoubleRange) depthNear;
+            (double or DoubleRange) depthFar;
+            (double or DoubleRange) focalLength;
+            (double or DoubleRange) horizontalFieldOfView;
+            (double or DoubleRange) verticalFieldOfView;
           };
         </pre>
       </section>


### PR DESCRIPTION
- Define non-constrainable property
- Apply the newly minted definition to:
  - focalLength
  - horizontalFieldOfView
  - verticalFieldOfView
