### PR TITLE
Fix #104: Define associated permission for a depth camera source

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,6 +262,13 @@
         "https://html.spec.whatwg.org/#videotrack"><dfn>VideoTrack</dfn></a></code>
         interfaces are defined in [[!HTML]].
       </p>
+      <p>
+        The term <a href=
+        "https://w3c.github.io/permissions/#permission"><dfn>permission</dfn></a>
+        and the permission name <code><a href=
+        "https://w3c.github.io/permissions/#dom-permissionname-camera">"<dfn>camera</dfn>"</a></code>
+        are defined in [[!PERMISSIONS]].
+      </p>
     </section>
     <section>
       <h2>
@@ -353,6 +360,10 @@
           <a>Constraints</a> dictionary, the <a>MediaStream</a> returned by the
           <a>getUserMedia()</a> method MUST contain a <a>depth stream track</a>
           that fulfills the specified mandatory constraints.
+        </p>
+        <p>
+          The <a>permission</a> associated with a depth camera <a>source</a> is
+          "<a>camera</a>",
         </p>
         <div class="note">
           If the user agent requests a combined <a>depth+video stream</a>, the


### PR DESCRIPTION
The Permissions API [says](https://w3c.github.io/permissions/#media-devices):

> The "camera", "microphone" , and "speaker" permissions are associated with permission to use media devices as specified in [GETUSERMEDIA] and [audio-output].

That suggests the "camera" permissions is generic, can be reused for depth. This PR defines that as such.

Fixes #104.
