### PR TITLE
Do not call echidna on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ script:
   - echo "ok"
 
 after_success:
-  - curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"
+  - test $TRAVIS_PULL_REQUEST = false 
+    && curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"


### PR DESCRIPTION
It is not needed to call echidna when PR are made but only when they get merged.

FYI this comes from: https://github.com/w3c/echidna/wiki/Setting-up-Echidna-as-a-GitHub-hook
(of course this change will have have to be integrated on the TR branch)
