### PR TITLE
Fix #125: define the data type of a depth map is 16-bit unsigned integer.

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,23 +226,9 @@
         or <a>depth+video stream</a>.
       </p>
       <p>
-        Depth cameras usually produce 16-bit depth values per pixel. However,
-        neither the canvas drawing surface used to draw and manipulate 2D
-        graphics on the web platform nor the <code><a>ImageData</a></code>
-        interface used to represent image data support 16 bits per pixel. To
-        address the issue, this specification defines a conversion into a 8-bit
-        grayscale representation of a <a>depth map</a> for consumption by APIs
-        that are limited to 8 bits per pixel.
-      </p>
-      <p>
-        The Media Capture Stream with Worker specification
-        [[MEDIACAPTURE-WORKER]] that complements this specification enables
-        processing of 16-bit depth values per pixel directly in a worker
-        environment and makes the <code>&lt;video&gt;</code> and
-        <code>&lt;canvas&gt;</code> indirection and depth-to-grayscale
-        conversion redundant. This alternative pipeline that supports greater
-        bit depth and does not incur the performance penalty of the indirection
-        and conversion enables more advanced use cases.
+        Depth cameras usually produce 16-bit depth values per pixel, so this
+        specification defines a 16-bit grayscale representation of a <a>depth
+        map</a>.
       </p>
     </section>
     <section>
@@ -414,170 +400,9 @@
           view</dfn> which is a double. It represents the vertical angle of
           view in degrees.
         </p>
-      </section>
-    </section>
-    <section>
-      <h2>
-        Extensions
-      </h2>
-      <section>
-        <h2>
-          <code><a>MediaStreamConstraints</a></code> dictionary
-        </h2>
-        <pre class="idl">
-          partial dictionary MediaStreamConstraints {
-              (boolean or MediaTrackConstraints) depth = false;
-          };
-        
-</pre>
-        <p dfn-for="MediaStreamConstraints" link-for="MediaStreamConstraints">
-          If the <dfn><code>depth</code></dfn> dictionary member has the value
-          true, the <a>MediaStream</a> returned by the <a>getUserMedia()</a>
-          method MUST contain a <a>depth stream track</a>. If the <a>depth</a>
-          dictionary member is set to false, is not provided, or is set to
-          null, the <a>MediaStream</a> MUST NOT contain a <a>depth stream
-          track</a>. If the <a>depth</a> dictionary member is set to a valid
-          <a>Constraints</a> dictionary, the <a>MediaStream</a> returned by the
-          <a>getUserMedia()</a> method MUST contain a <a>depth stream track</a>
-          that fulfills the specified mandatory constraints.
-        </p>
         <p>
-          The <a>permission</a> associated with a depth camera <a>source</a> is
-          "<a>camera</a>",
-        </p>
-        <div class="note">
-          If the user agent requests a combined <a>depth+video stream</a>, the
-          devices in the constraint should be satisfied as belonging to the
-          same group or physical device. The decision to select and satisfy
-          which device pair is left up to the implementation.
-        </div>
-      </section>
-      <section>
-        <h2>
-          <code>MediaStream</code> interface
-        </h2>
-        <pre class="idl">
-          partial interface MediaStream {
-              sequence&lt;MediaStreamTrack&gt; getDepthTracks();
-          };
-        
-</pre>
-        <p dfn-for="MediaStream" link-for="MediaStream">
-          The <code><dfn>getDepthTracks</dfn>()</code> method, when invoked,
-          MUST return a sequence of <a data-lt="depth stream track">depth
-          stream tracks</a> in this stream.
-        </p>
-        <p>
-          The <dfn><code>getDepthTracks()</code></dfn> method MUST return a
-          sequence that represents a snapshot of all the
-          <a><code>MediaStreamTrack</code></a> objects in this stream's track
-          set whose <a><code>kind</code></a> is equal to "<code>depth</code>".
-          The conversion from the track set to the sequence is <a>user
-          agent</a> defined and the order does not have to be stable between
-          calls.
-        </p>
-        <p>
-          The <a>MediaStream</a> <a>consumer</a> for the <a>depth-only
-          stream</a> and <a>depth+video stream</a> is <a href=
-          "#the-video-element">the <code>video</code> element</a> [[!HTML]].
-        </p>
-        <div class="note">
-          New <a>consumer</a>s may be added in a future version of this
-          specification.
-        </div>
-        <section class="informative">
-          <h3>
-            Implementation considerations
-          </h3>
-          <p>
-            A <a>video stream track</a> and a <a>depth stream track</a> can be
-            combined into one <a>depth+video stream</a>. The rendering of the
-            two tracks are intended to be synchronized. The resolution of the
-            two tracks are intended to be same. And the coordination of the two
-            tracks are intended to be calibrated. These are not hard
-            requirements, since it might not be possible to synchronize tracks
-            from sources.
-          </p>
-        </section>
-      </section>
-      <section>
-        <h2>
-          <code>MediaStreamTrack</code> interface
-        </h2>
-        <p>
-          The <code><dfn>kind</dfn></code> attribute MUST, on getting, return
-          the string "<code>depth</code>" if the object represents a <a>depth
-          stream track</a>.
-        </p>
-        <p>
-          If a <a>MediaStreamTrack</a> of <a>kind</a> "<code>depth</code>" is
-          <a>muted</a> or <a>disabled</a>, it MUST render black frames, or a
-          zero-information-content equivalent.
-        </p>
-      </section>
-      <section>
-        <h2>
-          <code>MediaDeviceInfo</code> interface
-        </h2>
-        <p>
-          The string "<code>depthinput</code>" is the <a>MediaDeviceKind</a>
-          value for the depth camera input device.
-        </p>
-      </section>
-      <section>
-        <h2>
-          Media provider object
-        </h2>
-        <p>
-          A <a href="https://html.spec.whatwg.org/#media-provider-object">media
-          provider object</a> can represent a <a>depth-only stream</a> (and
-          specifically, not a <a>depth+video stream</a>). The <a>user agent</a>
-          MUST support a <a href=
-          "https://html.spec.whatwg.org/#media-element">media element</a> with
-          an <a href=
-          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
-          media provider object</a> that is a <a>depth-only stream</a>, and in
-          particular, the <a href=
-          "https://html.spec.whatwg.org/#dom-media-srcobject"><code>srcObject</code></a>
-          IDL attribute that allows the <a href=
-          "https://html.spec.whatwg.org/#media-element">media element</a> to be
-          assigned a <a href=
-          "https://html.spec.whatwg.org/#media-provider-object">media provider
-          object</a> MUST, on setting and getting, behave as specified in
-          [[!HTML]].
-        </p>
-      </section>
-      <section>
-        <h2>
-          The <code>video</code> element
-        </h2>
-        <p>
-          For a <a href=
-          "https://html.spec.whatwg.org/#the-video-element"><code>video</code>
-          element</a> whose <a href=
-          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
-          media provider object</a> is a <a>depth-only stream</a>, the <a>user
-          agent</a> MUST, for each pixel of the <a href=
-          "https://html.spec.whatwg.org/#media-data">media data</a> that is
-          represented by a <a>depth map</a>, <a>convert the depth map value to
-          grayscale</a> prior to when the <code>video</code> element is
-          <a href="https://html.spec.whatwg.org/#potentially-playing">potentially
-          playing</a>.
-        </p>
-        <p>
-          For a <a href=
-          "https://html.spec.whatwg.org/#the-video-element"><code>video</code>
-          element</a> whose <a href=
-          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
-          media provider object</a> is a <a>depth+video stream</a>, the <a>user
-          agent</a> MUST act as if all the <a>MediaStreamTrack</a>s of kind
-          "<code>depth</code>" were removed prior to when the
-          <code>video</code> element is <a href=
-          "https://html.spec.whatwg.org/#potentially-playing">potentially
-          playing</a>.
-        </p>
-        <p>
-          The algorithm to <dfn>convert the depth map value to grayscale</dfn>,
+          The data type of a <a>depth map</a> is 16-bit unsigned integer. The
+          algorithm to <dfn>convert the depth map value to grayscale</dfn>,
           given a depth map value <var>d</var>, is as follows:
         </p>
         <ol>
@@ -588,7 +413,7 @@
           <li>Apply the <a>rules to convert using range inverse</a> to
           <var>d</var> to obtain quantized value <var>d<sub>8bit</sub>.</var>
           </li>
-          <li>Return <var>d<sub>8bit</sub></var>.
+          <li>Return <var>d<sub>16bit</sub></var>.
           </li>
         </ol>
         <p>
@@ -694,7 +519,7 @@
           "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-45"
           class="mjx-mrow" style=""><span id="MJXc-Node-46" class=
           "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-47"
+          "padding-top: 0.372em; padding-bottom: 0.372em;">16</span></span><span id="MJXc-Node-47"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
           "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-48"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
@@ -723,7 +548,7 @@
           "mjx-char MJXc-TeX-main-R" style=
           "padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-59"
           class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">255</span></span></span><span id="MJXc-Node-60"
+          "padding-top: 0.372em; padding-bottom: 0.372em;">65535</span></span></span><span id="MJXc-Node-60"
           class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style=
           "padding-top: 0.446em; padding-bottom: 0.593em;">⌋</span></span></span></span></span></span></span></span>
         </p>
@@ -734,9 +559,9 @@
             <var>d</var> as follows:
           </p>
           <ol>
-            <li>Given <var>d<sub>8bit</sub></var>, <var>near</var> <a>near
+            <li>Given <var>d<sub>16bit</sub></var>, <var>near</var> <a>near
             value</a> and <var>far</var> <a>far value</a>, normalize
-            <var>d<sub>8bit</sub></var> to [0, 1] range:
+            <var>d<sub>16bit</sub></var> to [0, 1] range:
               <p>
                 <span id="MathJax-Element-3-Frame" class="mjx-chtml"><span id=
                 "MJXc-Node-61" class="mjx-math" role="math"><span id=
@@ -756,10 +581,9 @@
                 "mjx-char MJXc-TeX-main-R" style=
                 "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-70"
                 class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style=
-                "width: 1.911em; padding: 0px 0.12em;"><span class=
-                "mjx-numerator" style=
-                "width: 1.911em; top: -1.447em;"><span id="MJXc-Node-71" class=
-                "mjx-msub"><span class="mjx-base" style=
+                "width: 2.7em; padding: 0px 0.12em;"><span class=
+                "mjx-numerator" style="width: 2.7em; top: -1.447em;"><span id=
+                "MJXc-Node-71" class="mjx-msub"><span class="mjx-base" style=
                 "margin-right: -0.003em;"><span id="MJXc-Node-72" class=
                 "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
                 "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
@@ -767,17 +591,16 @@
                 "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-73"
                 class="mjx-mrow" style=""><span id="MJXc-Node-74" class=
                 "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-                "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-75"
+                "padding-top: 0.372em; padding-bottom: 0.372em;">16</span></span><span id="MJXc-Node-75"
                 class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
                 "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-76"
                 class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
                 "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-77"
                 class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
                 "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span><span class="mjx-denominator"
-                style="width: 1.911em; bottom: -0.778em;"><span id=
-                "MJXc-Node-78" class="mjx-mn"><span class=
-                "mjx-char MJXc-TeX-main-R" style=
-                "padding-top: 0.372em; padding-bottom: 0.372em;">255</span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 1.911em;"
+                style="width: 2.7em; bottom: -0.778em;"><span id="MJXc-Node-78"
+                class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+                "padding-top: 0.372em; padding-bottom: 0.372em;">65535</span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 2.7em;"
                 class="mjx-line"></span></span><span style=
                 "height: 2.225em; vertical-align: -0.778em;" class=
                 "mjx-vsize"></span></span></span></span></span></span></span>
@@ -873,6 +696,250 @@
               </p>
             </li>
           </ol>
+        </div>
+      </section>
+    </section>
+    <section>
+      <h2>
+        Extensions
+      </h2>
+      <section>
+        <h2>
+          <code><a>MediaStreamConstraints</a></code> dictionary
+        </h2>
+        <pre class="idl">
+          partial dictionary MediaStreamConstraints {
+              (boolean or MediaTrackConstraints) depth = false;
+          };
+        
+</pre>
+        <p dfn-for="MediaStreamConstraints" link-for="MediaStreamConstraints">
+          If the <dfn><code>depth</code></dfn> dictionary member has the value
+          true, the <a>MediaStream</a> returned by the <a>getUserMedia()</a>
+          method MUST contain a <a>depth stream track</a>. If the <a>depth</a>
+          dictionary member is set to false, is not provided, or is set to
+          null, the <a>MediaStream</a> MUST NOT contain a <a>depth stream
+          track</a>. If the <a>depth</a> dictionary member is set to a valid
+          <a>Constraints</a> dictionary, the <a>MediaStream</a> returned by the
+          <a>getUserMedia()</a> method MUST contain a <a>depth stream track</a>
+          that fulfills the specified mandatory constraints.
+        </p>
+        <p>
+          The <a>permission</a> associated with a depth camera <a>source</a> is
+          "<a>camera</a>",
+        </p>
+        <div class="note">
+          If the user agent requests a combined <a>depth+video stream</a>, the
+          devices in the constraint should be satisfied as belonging to the
+          same group or physical device. The decision to select and satisfy
+          which device pair is left up to the implementation.
+        </div>
+      </section>
+      <section>
+        <h2>
+          <code>MediaStream</code> interface
+        </h2>
+        <pre class="idl">
+          partial interface MediaStream {
+              sequence&lt;MediaStreamTrack&gt; getDepthTracks();
+          };
+        
+</pre>
+        <p dfn-for="MediaStream" link-for="MediaStream">
+          The <code><dfn>getDepthTracks</dfn>()</code> method, when invoked,
+          MUST return a sequence of <a data-lt="depth stream track">depth
+          stream tracks</a> in this stream.
+        </p>
+        <p>
+          The <dfn><code>getDepthTracks()</code></dfn> method MUST return a
+          sequence that represents a snapshot of all the
+          <a><code>MediaStreamTrack</code></a> objects in this stream's track
+          set whose <a><code>kind</code></a> is equal to "<code>depth</code>".
+          The conversion from the track set to the sequence is <a>user
+          agent</a> defined and the order does not have to be stable between
+          calls.
+        </p>
+        <p>
+          The <a>MediaStream</a> <a>consumer</a> for the <a>depth-only
+          stream</a> and <a>depth+video stream</a> is <a href=
+          "#the-video-element">the <code>video</code> element</a> [[!HTML]].
+        </p>
+        <div class="note">
+          New <a>consumer</a>s may be added in a future version of this
+          specification.
+        </div>
+        <section class="informative">
+          <h3>
+            Implementation considerations
+          </h3>
+          <p>
+            A <a>video stream track</a> and a <a>depth stream track</a> can be
+            combined into one <a>depth+video stream</a>. The rendering of the
+            two tracks are intended to be synchronized. The resolution of the
+            two tracks are intended to be same. And the coordination of the two
+            tracks are intended to be calibrated. These are not hard
+            requirements, since it might not be possible to synchronize tracks
+            from sources.
+          </p>
+          <p>
+            There are two ways to access the 16 bit depth values.
+          </p>
+          <ol>
+            <li>
+              <code>16bit</code> texture in [[WEBGL]] after uploading a
+              <a>depth map</a> to the texture. For instance, <code>RGB</code>
+              and <code>LUMINANCE_ALPHA</code> are <code>16bit</code> texture.
+            </li>
+            <li>the Media Capture Stream with Worker specification
+            [[MEDIACAPTURE-WORKER]] that complements this specification enables
+            processing of 16-bit depth values per pixel directly in a worker
+            environment and makes the <code>&lt;video&gt;</code> and
+            <code>&lt;canvas&gt;</code> indirection and depth-to-grayscale
+            conversion redundant. This alternative pipeline that supports
+            greater bit depth and does not incur the performance penalty of the
+            indirection and conversion enables more advanced use cases.
+            </li>
+          </ol>
+        </section>
+      </section>
+      <section>
+        <h2>
+          <code>MediaStreamTrack</code> interface
+        </h2>
+        <p>
+          The <code><dfn>kind</dfn></code> attribute MUST, on getting, return
+          the string "<code>depth</code>" if the object represents a <a>depth
+          stream track</a>.
+        </p>
+        <p>
+          If a <a>MediaStreamTrack</a> of <a>kind</a> "<code>depth</code>" is
+          <a>muted</a> or <a>disabled</a>, it MUST render black frames, or a
+          zero-information-content equivalent.
+        </p>
+      </section>
+      <section>
+        <h2>
+          <code>MediaDeviceInfo</code> interface
+        </h2>
+        <p>
+          The string "<code>depthinput</code>" is the <a>MediaDeviceKind</a>
+          value for the depth camera input device.
+        </p>
+      </section>
+      <section>
+        <h2>
+          Media provider object
+        </h2>
+        <p>
+          A <a href="https://html.spec.whatwg.org/#media-provider-object">media
+          provider object</a> can represent a <a>depth-only stream</a> (and
+          specifically, not a <a>depth+video stream</a>). The <a>user agent</a>
+          MUST support a <a href=
+          "https://html.spec.whatwg.org/#media-element">media element</a> with
+          an <a href=
+          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
+          media provider object</a> that is a <a>depth-only stream</a>, and in
+          particular, the <a href=
+          "https://html.spec.whatwg.org/#dom-media-srcobject"><code>srcObject</code></a>
+          IDL attribute that allows the <a href=
+          "https://html.spec.whatwg.org/#media-element">media element</a> to be
+          assigned a <a href=
+          "https://html.spec.whatwg.org/#media-provider-object">media provider
+          object</a> MUST, on setting and getting, behave as specified in
+          [[!HTML]].
+        </p>
+      </section>
+      <section>
+        <h2>
+          The <code>video</code> element
+        </h2>
+        <p>
+          For a <a href=
+          "https://html.spec.whatwg.org/#the-video-element"><code>video</code>
+          element</a> whose <a href=
+          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
+          media provider object</a> is a <a>depth-only stream</a>, the <a>user
+          agent</a> MUST, for each pixel of the <a href=
+          "https://html.spec.whatwg.org/#media-data">media data</a> that is
+          represented by a <a>depth map</a>, <a>convert the depth map value to
+          grayscale</a> prior to when the <code>video</code> element is
+          <a href="https://html.spec.whatwg.org/#potentially-playing">potentially
+          playing</a>.
+        </p>
+        <p>
+          For a <a href=
+          "https://html.spec.whatwg.org/#the-video-element"><code>video</code>
+          element</a> whose <a href=
+          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
+          media provider object</a> is a <a>depth+video stream</a>, the <a>user
+          agent</a> MUST act as if all the <a>MediaStreamTrack</a>s of kind
+          "<code>depth</code>" were removed prior to when the
+          <code>video</code> element is <a href=
+          "https://html.spec.whatwg.org/#potentially-playing">potentially
+          playing</a>.
+        </p>
+        <p>
+          The <code>video</code> element draws the depth map after conversion
+          as follows:
+        </p>
+        <p>
+          <span id="MathJax-Element-5-Frame" class="mjx-chtml"><span id=
+          "MJXc-Node-116" class="mjx-math" role="math"><span id="MJXc-Node-117"
+          class="mjx-mrow"><span id="MJXc-Node-118" class=
+          "mjx-mstyle"><span id="MJXc-Node-119" class="mjx-mrow"><span id=
+          "MJXc-Node-120" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I"
+          style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-121"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-122"
+          class="mjx-msub"><span class="mjx-base" style=
+          "margin-right: -0.003em;"><span id="MJXc-Node-123" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
+          style=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-124"
+          class="mjx-mrow" style=""><span id="MJXc-Node-125" class=
+          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-126"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-127"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-128"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-129"
+          class="mjx-mo" style=
+          "padding-left: 0.333em; padding-right: 0.333em;"><span class=
+          "mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-130"
+          class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style=
+          "width: 2.265em; padding: 0px 0.12em;"><span class="mjx-numerator"
+          style="width: 2.265em; top: -1.447em;"><span id="MJXc-Node-131"
+          class="mjx-msub"><span class="mjx-base" style=
+          "margin-right: -0.003em;"><span id="MJXc-Node-132" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
+          style=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-133"
+          class="mjx-mrow" style=""><span id="MJXc-Node-134" class=
+          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">16</span></span><span id="MJXc-Node-135"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-136"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-137"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span><span class="mjx-denominator"
+          style="width: 2.265em; bottom: -0.778em;"><span id="MJXc-Node-138"
+          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">255</span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 2.265em;"
+          class="mjx-line"></span></span><span style=
+          "height: 2.225em; vertical-align: -0.778em;" class=
+          "mjx-vsize"></span></span></span></span></span></span></span>
+        </p>
+        <div class="note">
+          It is an implementation detail how the frames are rendered to the
+          screen. For example, the implementation may use a grayscale or red
+          channel representation.
         </div>
         <section>
           <h2>

--- a/index.html
+++ b/index.html
@@ -322,10 +322,35 @@
       </p>
       <p>
         The <code><a href=
-        "https://html.spec.whatwg.org/#imagedata"><dfn>ImageData</dfn></a></code>
-        and <code><a href=
-        "https://html.spec.whatwg.org/#videotrack"><dfn>VideoTrack</dfn></a></code>
-        interfaces are defined in [[!HTML]].
+        "https://html.spec.whatwg.org/multipage/embedded-content.html#the-video-element">
+        <dfn>video</dfn></a></code> element and <code><a href=
+        "https://html.spec.whatwg.org/multipage/scripting.html#imagedata"><dfn>ImageData</dfn></a></code>
+        (and its <code><a href=
+        "%20https://html.spec.whatwg.org/multipage/scripting.html#dom-imagedata-data">
+        <dfn>data</dfn></a></code> attribute and <a href=
+        "https://html.spec.whatwg.org/multipage/scripting.html#canvas-pixel-arraybuffer">
+        <dfn>Canvas Pixel <code>ArrayBuffer</code></dfn></a>), <code><a href=
+        "https://html.spec.whatwg.org/multipage/embedded-content.html#videotrack">
+        <dfn>VideoTrack</dfn></a></code>, <code><a href=
+        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">
+        <dfn>HTMLMediaElement</dfn></a></code> (and its <code><a href=
+        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-srcobject">
+        <dfn>srcObject</dfn></a></code> attribute), <code><a href=
+        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#htmlvideoelement">
+        <dfn>HTMLVideoElement</dfn></a></code> interfaces and the
+        <code><a href="%20https://html.spec.whatwg.org/multipage/scripting.html#canvasimagesource">
+        <dfn>CanvasImageSource</dfn></a></code> enum are defined in [[!HTML]].
+      </p>
+      <p>
+        The terms <a href=
+        "https://html.spec.whatwg.org/multipage/embedded-content.html#media-data">
+        <dfn>media data</dfn></a>, <a href=
+        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#media-provider-object">
+        <dfn>media provider object</dfn></a> , <a href=
+        "https://html.spec.whatwg.org/multipage/embedded-content.html#assigned-media-provider-object">
+        <dfn>assigned media provider object</dfn></a>, and the concept <a href=
+        "https://html.spec.whatwg.org/multipage/embedded-content.html#potentially-playing">
+        <dfn>potentially playing</dfn></a> are defined in [[!HTML]].
       </p>
       <p>
         The term <a href=
@@ -333,6 +358,15 @@
         and the permission name <code><a href=
         "https://w3c.github.io/permissions/#dom-permissionname-camera">"<dfn>camera</dfn>"</a></code>
         are defined in [[!PERMISSIONS]].
+      </p>
+      <p>
+        The <code><a href=
+        "http://heycam.github.io/webidl/#idl-DataView"><dfn>DataView</dfn></a></code>,
+        <code><a href=
+        "http://heycam.github.io/webidl/#idl-Uint8ClampedArray"><dfn>Uint8ClampedArray</dfn></a></code>,
+        and <code><a href=
+        "http://heycam.github.io/webidl/#idl-Uint16Array"><dfn>Uint16Array</dfn></a></code>
+        buffer source types are defined in [[WEBIDL]].
       </p>
     </section>
     <section>
@@ -403,7 +437,7 @@
         <p>
           The data type of a <a>depth map</a> is 16-bit unsigned integer. The
           algorithm to <dfn>convert the depth map value to grayscale</dfn>,
-          given a depth map value <var>d</var>, is as follows:
+          given a <dfn>depth map value</dfn> <var>d</var>, is as follows:
         </p>
         <ol>
           <li>Let <var>near</var> be the the <a>near value</a>.
@@ -735,25 +769,6 @@
             requirements, since it might not be possible to synchronize tracks
             from sources.
           </p>
-          <p>
-            There are two ways to access the 16 bit depth values.
-          </p>
-          <ol>
-            <li>
-              <code>16bit</code> texture in [[WEBGL]] after uploading a
-              <a>depth map</a> to the texture. For instance, <code>RGB</code>
-              and <code>LUMINANCE_ALPHA</code> are <code>16bit</code> texture.
-            </li>
-            <li>the Media Capture Stream with Worker specification
-            [[MEDIACAPTURE-WORKER]] that complements this specification enables
-            processing of 16-bit depth values per pixel directly in a worker
-            environment and makes the <code>&lt;video&gt;</code> and
-            <code>&lt;canvas&gt;</code> indirection and depth-to-grayscale
-            conversion redundant. This alternative pipeline that supports
-            greater bit depth and does not incur the performance penalty of the
-            indirection and conversion enables more advanced use cases.
-            </li>
-          </ol>
         </section>
       </section>
       <section>
@@ -785,22 +800,14 @@
           Media provider object
         </h2>
         <p>
-          A <a href="https://html.spec.whatwg.org/#media-provider-object">media
-          provider object</a> can represent a <a>depth-only stream</a> (and
-          specifically, not a <a>depth+video stream</a>). The <a>user agent</a>
-          MUST support a <a href=
-          "https://html.spec.whatwg.org/#media-element">media element</a> with
-          an <a href=
-          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
-          media provider object</a> that is a <a>depth-only stream</a>, and in
-          particular, the <a href=
-          "https://html.spec.whatwg.org/#dom-media-srcobject"><code>srcObject</code></a>
-          IDL attribute that allows the <a href=
-          "https://html.spec.whatwg.org/#media-element">media element</a> to be
-          assigned a <a href=
-          "https://html.spec.whatwg.org/#media-provider-object">media provider
-          object</a> MUST, on setting and getting, behave as specified in
-          [[!HTML]].
+          A <a>media provider object</a> can represent a <a>depth-only
+          stream</a> (and specifically, not a <a>depth+video stream</a>). The
+          <a>user agent</a> MUST support a <a>HTMLMediaElement</a> with an
+          <a>assigned media provider object</a> that is a <a>depth-only
+          stream</a>, and in particular, the <a>srcObject</a> IDL attribute
+          that allows the <a>HTMLMediaElement</a> to be assigned a <a>media
+          provider object</a> MUST, on setting and getting, behave as specified
+          in [[!HTML]].
         </p>
       </section>
       <section>
@@ -808,92 +815,25 @@
           The <code>video</code> element
         </h2>
         <p>
-          For a <a href=
-          "https://html.spec.whatwg.org/#the-video-element"><code>video</code>
-          element</a> whose <a href=
-          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
-          media provider object</a> is a <a>depth-only stream</a>, the <a>user
-          agent</a> MUST, for each pixel of the <a href=
-          "https://html.spec.whatwg.org/#media-data">media data</a> that is
-          represented by a <a>depth map</a>, <a>convert the depth map value to
-          grayscale</a> prior to when the <code>video</code> element is
-          <a href="https://html.spec.whatwg.org/#potentially-playing">potentially
-          playing</a>.
-        </p>
-        <p>
-          For a <a href=
-          "https://html.spec.whatwg.org/#the-video-element"><code>video</code>
-          element</a> whose <a href=
-          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
-          media provider object</a> is a <a>depth+video stream</a>, the <a>user
-          agent</a> MUST act as if all the <a>MediaStreamTrack</a>s of kind
-          "<code>depth</code>" were removed prior to when the
-          <code>video</code> element is <a href=
-          "https://html.spec.whatwg.org/#potentially-playing">potentially
-          playing</a>.
-        </p>
-        <p>
-          The <code>video</code> element draws the depth map after conversion
-          as follows:
-        </p>
-        <p>
-          <span id="MathJax-Element-5-Frame" class="mjx-chtml"><span id=
-          "MJXc-Node-97" class="mjx-math" role="math"><span id="MJXc-Node-98"
-          class="mjx-mrow"><span id="MJXc-Node-99" class="mjx-mstyle"><span id=
-          "MJXc-Node-100" class="mjx-mrow"><span id="MJXc-Node-101" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-102"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-103"
-          class="mjx-msub"><span class="mjx-base" style=
-          "margin-right: -0.003em;"><span id="MJXc-Node-104" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
-          style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-105"
-          class="mjx-mrow" style=""><span id="MJXc-Node-106" class=
-          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-107"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-108"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-109"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-110"
-          class="mjx-mo" style=
-          "padding-left: 0.333em; padding-right: 0.333em;"><span class=
-          "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-111"
-          class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style=
-          "width: 2.265em; padding: 0px 0.12em;"><span class="mjx-numerator"
-          style="width: 2.265em; top: -1.447em;"><span id="MJXc-Node-112"
-          class="mjx-msub"><span class="mjx-base" style=
-          "margin-right: -0.003em;"><span id="MJXc-Node-113" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
-          style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-114"
-          class="mjx-mrow" style=""><span id="MJXc-Node-115" class=
-          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">16</span></span><span id="MJXc-Node-116"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-117"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-118"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span><span class="mjx-denominator"
-          style="width: 2.265em; bottom: -0.778em;"><span id="MJXc-Node-119"
-          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">255</span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 2.265em;"
-          class="mjx-line"></span></span><span style=
-          "height: 2.225em; vertical-align: -0.778em;" class=
-          "mjx-vsize"></span></span></span></span></span></span></span>
+          When a <a>video</a> element is <a>potentially playing</a> and its
+          <a>assigned media provider object</a> is a <a>depth-only stream</a>,
+          the <a>user agent</a> MUST, for each pixel of the <a>media data</a>
+          that is represented by a <a>depth map</a>, given a depth map value
+          <em>d</em>, <a>convert the depth map value to grayscale</a> and
+          render the returned value to the screen.
         </p>
         <div class="note">
           It is an implementation detail how the frames are rendered to the
           screen. For example, the implementation may use a grayscale or red
-          channel representation.
+          representation, with either 8-bit or 16-bit precision.
         </div>
+        <p>
+          For a <a>video</a> element whose <a>assigned media provider
+          object</a> is a <a>depth+video stream</a>, the <a>user agent</a> MUST
+          act as if all the <a>MediaStreamTrack</a>s of kind
+          "<code>depth</code>" were removed prior to when the
+          <code>video</code> element is <a>potentially playing</a>.
+        </p>
         <section>
           <h2>
             <code>VideoTrack</code> interface
@@ -904,6 +844,279 @@
             as defined in [[HTML]].
           </p>
         </section>
+      </section>
+      <section>
+        <h2>
+          <code>ImageData</code> interface
+        </h2>
+        <p>
+          When an <a>ImageData</a> object's pixel values represent a <a>depth
+          map</a> (that is, the image source for the 2D rendering context
+          <a>CanvasImageSource</a> is a <a>HTMLVideoElement</a> whose <a>media
+          data</a> represents a <a>depth map</a>), its <a>Uint8ClampedArray</a>
+          source assigned to the <a>data</a> attribute represents the
+          <dfn>16-bit depth value</dfn> by assigning the low 8-bit of the
+          <a>16-bit depth value</a> <span id="MathJax-Element-5-Frame" class=
+          "mjx-chtml"><span id="MJXc-Node-97" class="mjx-math" role=
+          "math"><span id="MJXc-Node-98" class="mjx-mrow"><span id=
+          "MJXc-Node-99" class="mjx-mstyle"><span id="MJXc-Node-100" class=
+          "mjx-mrow"><span id="MJXc-Node-101" class="mjx-msub"><span class=
+          "mjx-base" style="margin-right: -0.003em;"><span id="MJXc-Node-102"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">
+          d</span></span></span><span class="mjx-sub" style=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-103"
+          class="mjx-mrow" style=""><span id="MJXc-Node-104" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">l</span></span><span id="MJXc-Node-105"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">o</span></span><span id="MJXc-Node-106"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">w</span></span><span id="MJXc-Node-107"
+          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-108"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-109"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-110"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span></span></span></span></span>
+          on its red component, and high 8-bit of the <a>16-bit depth value</a>
+          <span id="MathJax-Element-6-Frame" class="mjx-chtml"><span id=
+          "MJXc-Node-111" class="mjx-math" role="math"><span id="MJXc-Node-112"
+          class="mjx-mrow"><span id="MJXc-Node-113" class=
+          "mjx-mstyle"><span id="MJXc-Node-114" class="mjx-mrow"><span id=
+          "MJXc-Node-115" class="mjx-msub"><span class="mjx-base" style=
+          "margin-right: -0.003em;"><span id="MJXc-Node-116" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">
+          d</span></span></span><span class="mjx-sub" style=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-117"
+          class="mjx-mrow" style=""><span id="MJXc-Node-118" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-119"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-120"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.003em;">g</span></span><span id="MJXc-Node-121"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-122"
+          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-123"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-124"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-125"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span></span></span></span></span>
+          on its green component.
+        </p>
+        <p>
+          If the values are read from the default <a>Uint8ClampedArray</a>
+          view, they are represented as <a>Canvas Pixel
+          <code>ArrayBuffer</code></a> data as follows:
+        </p>
+        <p>
+          <span id="MathJax-Element-7-Frame" class="mjx-chtml"><span id=
+          "MJXc-Node-126" class="mjx-math" role="math"><span id="MJXc-Node-127"
+          class="mjx-mrow"><span id="MJXc-Node-128" class=
+          "mjx-mstyle"><span id="MJXc-Node-129" class="mjx-mrow"><span id=
+          "MJXc-Node-130" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I"
+          style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-131"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-132"
+          class="mjx-msub"><span class="mjx-base" style=
+          "margin-right: -0.003em;"><span id="MJXc-Node-133" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
+          style=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-134"
+          class="mjx-mrow" style=""><span id="MJXc-Node-135" class=
+          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-136"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-137"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-138"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-139"
+          class="mjx-mo" style=
+          "padding-left: 0.333em; padding-right: 0.333em;"><span class=
+          "mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-140"
+          class="mjx-msub"><span class="mjx-base" style=
+          "margin-right: -0.003em;"><span id="MJXc-Node-141" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
+          style=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-142"
+          class="mjx-mrow" style=""><span id="MJXc-Node-143" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">l</span></span><span id="MJXc-Node-144"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">o</span></span><span id="MJXc-Node-145"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">w</span></span><span id="MJXc-Node-146"
+          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-147"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-148"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-149"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span></span></span></span></span>
+        </p>
+        <p>
+          <span id="MathJax-Element-8-Frame" class="mjx-chtml"><span id=
+          "MJXc-Node-150" class="mjx-math" role="math"><span id="MJXc-Node-151"
+          class="mjx-mrow"><span id="MJXc-Node-152" class=
+          "mjx-mstyle"><span id="MJXc-Node-153" class="mjx-mrow"><span id=
+          "MJXc-Node-154" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I"
+          style=
+          "padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.003em;">
+          g</span></span><span id="MJXc-Node-155" class="mjx-mi"><span class=
+          "mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-156"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-157"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-158"
+          class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-159"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span></span><span class="mjx-sub"
+          style=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-160"
+          class="mjx-mrow" style=""><span id="MJXc-Node-161" class=
+          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-162"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-163"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-164"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-165"
+          class="mjx-mo" style=
+          "padding-left: 0.333em; padding-right: 0.333em;"><span class=
+          "mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-166"
+          class="mjx-msub"><span class="mjx-base" style=
+          "margin-right: -0.003em;"><span id="MJXc-Node-167" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
+          style=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-168"
+          class="mjx-mrow" style=""><span id="MJXc-Node-169" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-170"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-171"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.003em;">g</span></span><span id="MJXc-Node-172"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-173"
+          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-174"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-175"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-176"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span></span></span></span></span>
+        </p>
+        <p>
+          <span id="MathJax-Element-9-Frame" class="mjx-chtml"><span id=
+          "MJXc-Node-177" class="mjx-math" role="math"><span id="MJXc-Node-178"
+          class="mjx-mrow"><span id="MJXc-Node-179" class=
+          "mjx-mstyle"><span id="MJXc-Node-180" class="mjx-mrow"><span id=
+          "MJXc-Node-181" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I"
+          style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-182"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">l</span></span><span id="MJXc-Node-183"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">u</span></span><span id="MJXc-Node-184"
+          class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-185"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span></span><span class="mjx-sub"
+          style=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-186"
+          class="mjx-mrow" style=""><span id="MJXc-Node-187" class=
+          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-188"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-189"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-190"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-191"
+          class="mjx-mo" style=
+          "padding-left: 0.333em; padding-right: 0.333em;"><span class=
+          "mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-192"
+          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">0</span></span></span></span></span></span></span>
+        </p>
+        <p>
+          <span id="MathJax-Element-10-Frame" class="mjx-chtml"><span id=
+          "MJXc-Node-193" class="mjx-math" role="math"><span id="MJXc-Node-194"
+          class="mjx-mrow"><span id="MJXc-Node-195" class=
+          "mjx-mstyle"><span id="MJXc-Node-196" class="mjx-mrow"><span id=
+          "MJXc-Node-197" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I"
+          style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-198"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">l</span></span><span id="MJXc-Node-199"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-200"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-201"
+          class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-202"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span></span><span class="mjx-sub"
+          style=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-203"
+          class="mjx-mrow" style=""><span id="MJXc-Node-204" class=
+          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-205"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-206"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-207"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-208"
+          class="mjx-mo" style=
+          "padding-left: 0.333em; padding-right: 0.333em;"><span class=
+          "mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-209"
+          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
+          "padding-top: 0.372em; padding-bottom: 0.372em;">0</span></span></span></span></span></span></span>
+        </p>
+        <pre class="example highlight">
+          var depthVideo = document.querySelector('video');
+          var canvas = document.querySelector('canvas');
+          var context = canvas.getContext('2d');
+          var w = depthVideo.videoWidth, h = depthVideo.videoHeight;
+
+          context.drawImage(depthVideo, 0, 0, w, h);
+          var imageData = context.getImageData(0, 0, w, h);
+
+          // Create a new DataView dv on to an ArrayBuffer buffer
+          // that exposes it as an array of unsigned 16-bit integers.
+          var dv = new DataView(imageData.data.buffer);
+
+          // Read every fourth unsigned 16-bit value in little endian representation.
+          for (var i = 0; i &lt; imageData.data.length; i += 4) {
+            console.log(dv.getUint16(i, true));
+          }
+
+          // Alternatively, reconstruct unsigned 16-bit value. The result
+          // is the same as if DataView and getUint16() was used.
+          for (var i = 0; i &lt; imageData.data.length; i += 4) {
+            console.log(imageData.data[i] + (imageData.data[i+1] &lt;&lt; 8));
+          }
+        
+</pre>
       </section>
       <section>
         <h2>
@@ -1093,6 +1306,9 @@
           <h3>
             Implementation considerations
           </h3>
+          <div class="note">
+            This section is currently work in progress, and subject to change.
+          </div>
           <p>
             A <code>video</code> element whose source is a
             <a><code>MediaStream</code></a> object containing a <a>depth stream

--- a/index.html
+++ b/index.html
@@ -410,14 +410,14 @@
           </li>
           <li>Let <var>far</var> be the the <a>far value</a>.
           </li>
-          <li>Apply the <a>rules to convert using range inverse</a> to
-          <var>d</var> to obtain quantized value <var>d<sub>8bit</sub>.</var>
+          <li>Apply the <a>rules to convert using range linear</a> to
+          <var>d</var> to obtain quantized value <var>d<sub>16bit</sub>.</var>
           </li>
           <li>Return <var>d<sub>16bit</sub></var>.
           </li>
         </ol>
         <p>
-          The <dfn>rules to convert using range inverse</dfn> are as given in
+          The <dfn>rules to convert using range linear</dfn> are as given in
           the following formula:
         </p>
         <p>
@@ -439,123 +439,97 @@
           "mjx-char MJXc-TeX-main-R" style=
           "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-10"
           class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style=
-          "width: 7.2em; padding: 0px 0.12em;"><span class="mjx-numerator"
-          style="width: 7.2em; top: -1.59em;"><span id="MJXc-Node-11" class=
+          "width: 5.087em; padding: 0px 0.12em;"><span class="mjx-numerator"
+          style="width: 5.087em; top: -1.396em;"><span id="MJXc-Node-11" class=
           "mjx-mrow"><span id="MJXc-Node-12" class="mjx-mi"><span class=
           "mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-13"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-14"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-15"
+          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-13"
           class="mjx-mo" style=
           "padding-left: 0.267em; padding-right: 0.267em;"><span class=
           "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-16"
-          class="mjx-mrow"><span id="MJXc-Node-17" class="mjx-mo"><span class=
-          "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.446em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-18"
+          "margin-top: 0.004em; padding-bottom: 0.298em;">−</span></span><span id="MJXc-Node-14"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-19"
-          class="mjx-mo" style=
-          "padding-left: 0.267em; padding-right: 0.267em;"><span class=
-          "mjx-char MJXc-TeX-main-R" style=
-          "margin-top: 0.004em; padding-bottom: 0.298em;">−</span></span><span id="MJXc-Node-20"
+          "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-15"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-21"
+          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-16"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-22"
+          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-17"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-23"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-24"
-          class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.446em; padding-bottom: 0.593em;">)</span></span></span></span></span><span class="mjx-denominator"
-          style="width: 7.2em; bottom: -1.09em;"><span id="MJXc-Node-25" class=
-          "mjx-mrow"><span id="MJXc-Node-26" class="mjx-mi"><span class=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span></span></span><span class="mjx-denominator"
+          style="width: 5.087em; bottom: -1em;"><span id="MJXc-Node-18" class=
+          "mjx-mrow"><span id="MJXc-Node-19" class="mjx-mi"><span class=
           "mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-27"
+          "padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-20"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-21"
+          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-22"
           class="mjx-mo" style=
           "padding-left: 0.267em; padding-right: 0.267em;"><span class=
           "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-28"
-          class="mjx-mrow"><span id="MJXc-Node-29" class="mjx-mo"><span class=
-          "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.446em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-30"
+          "margin-top: 0.004em; padding-bottom: 0.298em;">−</span></span><span id="MJXc-Node-23"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-31"
+          "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-24"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-32"
+          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-25"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-33"
-          class="mjx-mo" style=
-          "padding-left: 0.267em; padding-right: 0.267em;"><span class=
-          "mjx-char MJXc-TeX-main-R" style=
-          "margin-top: 0.004em; padding-bottom: 0.298em;">−</span></span><span id="MJXc-Node-34"
+          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-26"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-35"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-36"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-37"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-38"
-          class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.446em; padding-bottom: 0.593em;">)</span></span></span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 7.2em;"
+          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 5.087em;"
           class="mjx-line"></span></span><span style=
-          "height: 2.68em; vertical-align: -1.09em;" class=
+          "height: 2.396em; vertical-align: -1em;" class=
           "mjx-vsize"></span></span></span></span></span></span></span>
         </p>
         <p>
           <span id="MathJax-Element-2-Frame" class="mjx-chtml"><span id=
-          "MJXc-Node-39" class="mjx-math" role="math"><span id="MJXc-Node-40"
-          class="mjx-mrow"><span id="MJXc-Node-41" class="mjx-mstyle"><span id=
-          "MJXc-Node-42" class="mjx-mrow"><span id="MJXc-Node-43" class=
+          "MJXc-Node-27" class="mjx-math" role="math"><span id="MJXc-Node-28"
+          class="mjx-mrow"><span id="MJXc-Node-29" class="mjx-mstyle"><span id=
+          "MJXc-Node-30" class="mjx-mrow"><span id="MJXc-Node-31" class=
           "mjx-msub"><span class="mjx-base" style=
-          "margin-right: -0.003em;"><span id="MJXc-Node-44" class=
+          "margin-right: -0.003em;"><span id="MJXc-Node-32" class=
           "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
           "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">
           d</span></span></span><span class="mjx-sub" style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-45"
-          class="mjx-mrow" style=""><span id="MJXc-Node-46" class=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-33"
+          class="mjx-mrow" style=""><span id="MJXc-Node-34" class=
           "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">16</span></span><span id="MJXc-Node-47"
+          "padding-top: 0.372em; padding-bottom: 0.372em;">16</span></span><span id="MJXc-Node-35"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-48"
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-36"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-49"
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-37"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-50"
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-38"
           class="mjx-mo" style=
           "padding-left: 0.333em; padding-right: 0.333em;"><span class=
           "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-51"
-          class="mjx-mrow"><span id="MJXc-Node-52" class="mjx-mo"><span class=
+          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-39"
+          class="mjx-mrow"><span id="MJXc-Node-40" class="mjx-mo"><span class=
           "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.446em; padding-bottom: 0.593em;">⌊</span></span><span id="MJXc-Node-53"
-          class="mjx-mrow"><span id="MJXc-Node-54" class=
+          "padding-top: 0.446em; padding-bottom: 0.593em;">⌊</span></span><span id="MJXc-Node-41"
+          class="mjx-mrow"><span id="MJXc-Node-42" class=
           "mjx-msub"><span class="mjx-base" style=
-          "margin-right: -0.003em;"><span id="MJXc-Node-55" class=
+          "margin-right: -0.003em;"><span id="MJXc-Node-43" class=
           "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
           "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
           style=
-          "font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-56"
-          class="mjx-mrow" style=""><span id="MJXc-Node-57" class=
+          "font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-44"
+          class="mjx-mrow" style=""><span id="MJXc-Node-45" class=
           "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span></span></span></span><span id="MJXc-Node-58"
+          "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span></span></span></span><span id="MJXc-Node-46"
           class="mjx-mo" style=
           "padding-left: 0.267em; padding-right: 0.267em;"><span class=
           "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-59"
+          "padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-47"
           class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">65535</span></span></span><span id="MJXc-Node-60"
+          "padding-top: 0.372em; padding-bottom: 0.372em;">65535</span></span></span><span id="MJXc-Node-48"
           class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style=
           "padding-top: 0.446em; padding-bottom: 0.593em;">⌋</span></span></span></span></span></span></span></span>
         </p>
         <div class="note">
           <p>
             The depth measurement <var>d</var> (in meter units) is recovered by
-            solving the <a>rules to convert using range inverse</a> for
+            solving the <a>rules to convert using range linear</a> for
             <var>d</var> as follows:
           </p>
           <ol>
@@ -564,41 +538,41 @@
             <var>d<sub>16bit</sub></var> to [0, 1] range:
               <p>
                 <span id="MathJax-Element-3-Frame" class="mjx-chtml"><span id=
-                "MJXc-Node-61" class="mjx-math" role="math"><span id=
-                "MJXc-Node-62" class="mjx-mrow"><span id="MJXc-Node-63" class=
-                "mjx-mstyle"><span id="MJXc-Node-64" class="mjx-mrow"><span id=
-                "MJXc-Node-65" class="mjx-msub"><span class="mjx-base" style=
-                "margin-right: -0.003em;"><span id="MJXc-Node-66" class=
+                "MJXc-Node-49" class="mjx-math" role="math"><span id=
+                "MJXc-Node-50" class="mjx-mrow"><span id="MJXc-Node-51" class=
+                "mjx-mstyle"><span id="MJXc-Node-52" class="mjx-mrow"><span id=
+                "MJXc-Node-53" class="mjx-msub"><span class="mjx-base" style=
+                "margin-right: -0.003em;"><span id="MJXc-Node-54" class=
                 "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
                 "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">
                 d</span></span></span><span class="mjx-sub" style=
-                "font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-67"
-                class="mjx-mrow" style=""><span id="MJXc-Node-68" class=
+                "font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-55"
+                class="mjx-mrow" style=""><span id="MJXc-Node-56" class=
                 "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span></span></span></span><span id="MJXc-Node-69"
+                "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span></span></span></span><span id="MJXc-Node-57"
                 class="mjx-mo" style=
                 "padding-left: 0.333em; padding-right: 0.333em;"><span class=
                 "mjx-char MJXc-TeX-main-R" style=
-                "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-70"
+                "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-58"
                 class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style=
                 "width: 2.7em; padding: 0px 0.12em;"><span class=
                 "mjx-numerator" style="width: 2.7em; top: -1.447em;"><span id=
-                "MJXc-Node-71" class="mjx-msub"><span class="mjx-base" style=
-                "margin-right: -0.003em;"><span id="MJXc-Node-72" class=
+                "MJXc-Node-59" class="mjx-msub"><span class="mjx-base" style=
+                "margin-right: -0.003em;"><span id="MJXc-Node-60" class=
                 "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
                 "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
                 style=
-                "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-73"
-                class="mjx-mrow" style=""><span id="MJXc-Node-74" class=
+                "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-61"
+                class="mjx-mrow" style=""><span id="MJXc-Node-62" class=
                 "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-                "padding-top: 0.372em; padding-bottom: 0.372em;">16</span></span><span id="MJXc-Node-75"
+                "padding-top: 0.372em; padding-bottom: 0.372em;">16</span></span><span id="MJXc-Node-63"
                 class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-76"
+                "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-64"
                 class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-77"
+                "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-65"
                 class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
                 "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span><span class="mjx-denominator"
-                style="width: 2.7em; bottom: -0.778em;"><span id="MJXc-Node-78"
+                style="width: 2.7em; bottom: -0.778em;"><span id="MJXc-Node-66"
                 class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
                 "padding-top: 0.372em; padding-bottom: 0.372em;">65535</span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 2.7em;"
                 class="mjx-line"></span></span><span style=
@@ -606,93 +580,73 @@
                 "mjx-vsize"></span></span></span></span></span></span></span>
               </p>
             </li>
-            <li>Solve the <a>rules to convert using range inverse</a> for <var>
+            <li>Solve the <a>rules to convert using range linear</a> for <var>
               d</var>:
               <p>
                 <span id="MathJax-Element-4-Frame" class="mjx-chtml"><span id=
-                "MJXc-Node-79" class="mjx-math" role="math"><span id=
-                "MJXc-Node-80" class="mjx-mrow"><span id="MJXc-Node-81" class=
-                "mjx-mstyle"><span id="MJXc-Node-82" class="mjx-mrow"><span id=
-                "MJXc-Node-83" class="mjx-mi"><span class=
+                "MJXc-Node-67" class="mjx-math" role="math"><span id=
+                "MJXc-Node-68" class="mjx-mrow"><span id="MJXc-Node-69" class=
+                "mjx-mstyle"><span id="MJXc-Node-70" class="mjx-mrow"><span id=
+                "MJXc-Node-71" class="mjx-mi"><span class=
                 "mjx-char MJXc-TeX-math-I" style=
                 "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">
-                d</span></span><span id="MJXc-Node-84" class="mjx-mo" style=
+                d</span></span><span id="MJXc-Node-72" class="mjx-mo" style=
                 "padding-left: 0.333em; padding-right: 0.333em;"><span class=
                 "mjx-char MJXc-TeX-main-R" style=
-                "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-85"
-                class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style=
-                "width: 10.498em; padding: 0px 0.12em;"><span class=
-                "mjx-numerator" style="width: 10.498em; top: -1.5em;"><span id=
-                "MJXc-Node-86" class="mjx-mrow"><span id="MJXc-Node-87" class=
+                "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-73"
+                class="mjx-mrow"><span id="MJXc-Node-74" class=
+                "mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style=
+                "padding-top: 0.446em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-75"
+                class="mjx-msub"><span class="mjx-base" style=
+                "margin-right: -0.003em;"><span id="MJXc-Node-76" class=
                 "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-88"
+                "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
+                style=
+                "font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-77"
+                class="mjx-mrow" style=""><span id="MJXc-Node-78" class=
+                "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+                "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span></span></span></span><span id="MJXc-Node-79"
+                class="mjx-mo" style=
+                "padding-left: 0.267em; padding-right: 0.267em;"><span class=
+                "mjx-char MJXc-TeX-main-R" style=
+                "padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-80"
+                class="mjx-mrow"><span id="MJXc-Node-81" class=
+                "mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style=
+                "padding-top: 0.446em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-82"
+                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+                "padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-83"
+                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+                "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-84"
+                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+                "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-85"
+                class="mjx-mo" style=
+                "padding-left: 0.267em; padding-right: 0.267em;"><span class=
+                "mjx-char MJXc-TeX-main-R" style=
+                "margin-top: 0.004em; padding-bottom: 0.298em;">−</span></span><span id="MJXc-Node-86"
+                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+                "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-87"
+                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+                "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-88"
                 class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
                 "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-89"
                 class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
                 "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-90"
-                class="mjx-mo" style=
-                "padding-left: 0.267em; padding-right: 0.267em;"><span class=
-                "mjx-char MJXc-TeX-main-R" style=
-                "padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-91"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-92"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-93"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-94"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span></span></span><span class="mjx-denominator"
-                style="width: 10.498em; bottom: -1.09em;"><span id=
-                "MJXc-Node-95" class="mjx-mrow"><span id="MJXc-Node-96" class=
-                "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-97"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-98"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-99"
-                class="mjx-mo" style=
-                "padding-left: 0.267em; padding-right: 0.267em;"><span class=
-                "mjx-char MJXc-TeX-main-R" style=
-                "margin-top: 0.004em; padding-bottom: 0.298em;">−</span></span><span id="MJXc-Node-100"
-                class="mjx-msub"><span class="mjx-base" style=
-                "margin-right: -0.003em;"><span id="MJXc-Node-101" class=
-                "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
-                style=
-                "font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-102"
-                class="mjx-mrow" style=""><span id="MJXc-Node-103" class=
-                "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span></span></span></span><span id="MJXc-Node-104"
-                class="mjx-mo" style=
-                "padding-left: 0.267em; padding-right: 0.267em;"><span class=
-                "mjx-char MJXc-TeX-main-R" style=
-                "padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-105"
-                class="mjx-mrow"><span id="MJXc-Node-106" class=
-                "mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style=
-                "padding-top: 0.446em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-107"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-108"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-109"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-110"
-                class="mjx-mo" style=
-                "padding-left: 0.267em; padding-right: 0.267em;"><span class=
-                "mjx-char MJXc-TeX-main-R" style=
-                "margin-top: 0.004em; padding-bottom: 0.298em;">−</span></span><span id="MJXc-Node-111"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-112"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-113"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-114"
-                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-                "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-115"
                 class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style=
-                "padding-top: 0.446em; padding-bottom: 0.593em;">)</span></span></span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 10.498em;"
-                class="mjx-line"></span></span><span style=
-                "height: 2.59em; vertical-align: -1.09em;" class=
-                "mjx-vsize"></span></span></span></span></span></span></span>
+                "padding-top: 0.446em; padding-bottom: 0.593em;">)</span></span></span><span id="MJXc-Node-91"
+                class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style=
+                "padding-top: 0.446em; padding-bottom: 0.593em;">)</span></span></span><span id="MJXc-Node-92"
+                class="mjx-mo" style=
+                "padding-left: 0.267em; padding-right: 0.267em;"><span class=
+                "mjx-char MJXc-TeX-main-R" style=
+                "padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-93"
+                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+                "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-94"
+                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+                "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-95"
+                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+                "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-96"
+                class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+                "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span></span></span></span></span></span>
               </p>
             </li>
           </ol>
@@ -884,52 +838,51 @@
         </p>
         <p>
           <span id="MathJax-Element-5-Frame" class="mjx-chtml"><span id=
-          "MJXc-Node-116" class="mjx-math" role="math"><span id="MJXc-Node-117"
-          class="mjx-mrow"><span id="MJXc-Node-118" class=
-          "mjx-mstyle"><span id="MJXc-Node-119" class="mjx-mrow"><span id=
-          "MJXc-Node-120" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I"
-          style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-121"
+          "MJXc-Node-97" class="mjx-math" role="math"><span id="MJXc-Node-98"
+          class="mjx-mrow"><span id="MJXc-Node-99" class="mjx-mstyle"><span id=
+          "MJXc-Node-100" class="mjx-mrow"><span id="MJXc-Node-101" class=
+          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
+          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-102"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-122"
+          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-103"
           class="mjx-msub"><span class="mjx-base" style=
-          "margin-right: -0.003em;"><span id="MJXc-Node-123" class=
+          "margin-right: -0.003em;"><span id="MJXc-Node-104" class=
           "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
           "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
           style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-124"
-          class="mjx-mrow" style=""><span id="MJXc-Node-125" class=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-105"
+          class="mjx-mrow" style=""><span id="MJXc-Node-106" class=
           "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-126"
+          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-107"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-127"
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-108"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-128"
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-109"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-129"
+          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-110"
           class="mjx-mo" style=
           "padding-left: 0.333em; padding-right: 0.333em;"><span class=
           "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-130"
+          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-111"
           class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style=
           "width: 2.265em; padding: 0px 0.12em;"><span class="mjx-numerator"
-          style="width: 2.265em; top: -1.447em;"><span id="MJXc-Node-131"
+          style="width: 2.265em; top: -1.447em;"><span id="MJXc-Node-112"
           class="mjx-msub"><span class="mjx-base" style=
-          "margin-right: -0.003em;"><span id="MJXc-Node-132" class=
+          "margin-right: -0.003em;"><span id="MJXc-Node-113" class=
           "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
           "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
           style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-133"
-          class="mjx-mrow" style=""><span id="MJXc-Node-134" class=
+          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-114"
+          class="mjx-mrow" style=""><span id="MJXc-Node-115" class=
           "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">16</span></span><span id="MJXc-Node-135"
+          "padding-top: 0.372em; padding-bottom: 0.372em;">16</span></span><span id="MJXc-Node-116"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-136"
+          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-117"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-137"
+          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-118"
           class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
           "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span><span class="mjx-denominator"
-          style="width: 2.265em; bottom: -0.778em;"><span id="MJXc-Node-138"
+          style="width: 2.265em; bottom: -0.778em;"><span id="MJXc-Node-119"
           class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
           "padding-top: 0.372em; padding-bottom: 0.372em;">255</span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 2.265em;"
           class="mjx-line"></span></span><span style=
@@ -1218,7 +1171,6 @@ gl.texImage2D(
   uniform sampler2D u_tex;
   uniform float far;
   uniform float near;
-  uniform bool isRangeInverse;
   void main() {
     vec4 floatColor = texture2D(u_tex, v_texCoord);
     float dn = floatColor.r;
@@ -1252,7 +1204,7 @@ gl.texImage2D(
         Project Tango for their experiments.
       </p>
       <p>
-        The range inverse format [[!XDM]] is licensed under <a href=
+        The range linear format [[!XDM]] is licensed under <a href=
         "http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -856,60 +856,9 @@
           data</a> represents a <a>depth map</a>), its <a>Uint8ClampedArray</a>
           source assigned to the <a>data</a> attribute represents the
           <dfn>16-bit depth value</dfn> by assigning the low 8-bit of the
-          <a>16-bit depth value</a> <span id="MathJax-Element-5-Frame" class=
-          "mjx-chtml"><span id="MJXc-Node-97" class="mjx-math" role=
-          "math"><span id="MJXc-Node-98" class="mjx-mrow"><span id=
-          "MJXc-Node-99" class="mjx-mstyle"><span id="MJXc-Node-100" class=
-          "mjx-mrow"><span id="MJXc-Node-101" class="mjx-msub"><span class=
-          "mjx-base" style="margin-right: -0.003em;"><span id="MJXc-Node-102"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">
-          d</span></span></span><span class="mjx-sub" style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-103"
-          class="mjx-mrow" style=""><span id="MJXc-Node-104" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">l</span></span><span id="MJXc-Node-105"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">o</span></span><span id="MJXc-Node-106"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">w</span></span><span id="MJXc-Node-107"
-          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-108"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-109"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-110"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span></span></span></span></span>
-          on its red component, and high 8-bit of the <a>16-bit depth value</a>
-          <span id="MathJax-Element-6-Frame" class="mjx-chtml"><span id=
-          "MJXc-Node-111" class="mjx-math" role="math"><span id="MJXc-Node-112"
-          class="mjx-mrow"><span id="MJXc-Node-113" class=
-          "mjx-mstyle"><span id="MJXc-Node-114" class="mjx-mrow"><span id=
-          "MJXc-Node-115" class="mjx-msub"><span class="mjx-base" style=
-          "margin-right: -0.003em;"><span id="MJXc-Node-116" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">
-          d</span></span></span><span class="mjx-sub" style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-117"
-          class="mjx-mrow" style=""><span id="MJXc-Node-118" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-119"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-120"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.003em;">g</span></span><span id="MJXc-Node-121"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-122"
-          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-123"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-124"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-125"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span></span></span></span></span>
-          on its green component.
+          <a>16-bit depth value</a> <em>d<sub>low8bit</sub></em> on its red
+          component, and high 8-bit of the <a>16-bit depth value</a>
+          <em>d<sub>high8bit</sub></em> on its green component.
         </p>
         <p>
           If the values are read from the default <a>Uint8ClampedArray</a>
@@ -917,180 +866,16 @@
           <code>ArrayBuffer</code></a> data as follows:
         </p>
         <p>
-          <span id="MathJax-Element-7-Frame" class="mjx-chtml"><span id=
-          "MJXc-Node-126" class="mjx-math" role="math"><span id="MJXc-Node-127"
-          class="mjx-mrow"><span id="MJXc-Node-128" class=
-          "mjx-mstyle"><span id="MJXc-Node-129" class="mjx-mrow"><span id=
-          "MJXc-Node-130" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I"
-          style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-131"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-132"
-          class="mjx-msub"><span class="mjx-base" style=
-          "margin-right: -0.003em;"><span id="MJXc-Node-133" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
-          style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-134"
-          class="mjx-mrow" style=""><span id="MJXc-Node-135" class=
-          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-136"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-137"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-138"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-139"
-          class="mjx-mo" style=
-          "padding-left: 0.333em; padding-right: 0.333em;"><span class=
-          "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-140"
-          class="mjx-msub"><span class="mjx-base" style=
-          "margin-right: -0.003em;"><span id="MJXc-Node-141" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
-          style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-142"
-          class="mjx-mrow" style=""><span id="MJXc-Node-143" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">l</span></span><span id="MJXc-Node-144"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">o</span></span><span id="MJXc-Node-145"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">w</span></span><span id="MJXc-Node-146"
-          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-147"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-148"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-149"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span></span></span></span></span>
+          <em>red<sub>8bit</sub> = d<sub>low8bit</sub></em>
         </p>
         <p>
-          <span id="MathJax-Element-8-Frame" class="mjx-chtml"><span id=
-          "MJXc-Node-150" class="mjx-math" role="math"><span id="MJXc-Node-151"
-          class="mjx-mrow"><span id="MJXc-Node-152" class=
-          "mjx-mstyle"><span id="MJXc-Node-153" class="mjx-mrow"><span id=
-          "MJXc-Node-154" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I"
-          style=
-          "padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.003em;">
-          g</span></span><span id="MJXc-Node-155" class="mjx-mi"><span class=
-          "mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-156"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-157"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-158"
-          class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-159"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span></span><span class="mjx-sub"
-          style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-160"
-          class="mjx-mrow" style=""><span id="MJXc-Node-161" class=
-          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-162"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-163"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-164"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-165"
-          class="mjx-mo" style=
-          "padding-left: 0.333em; padding-right: 0.333em;"><span class=
-          "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-166"
-          class="mjx-msub"><span class="mjx-base" style=
-          "margin-right: -0.003em;"><span id="MJXc-Node-167" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span></span><span class="mjx-sub"
-          style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-168"
-          class="mjx-mrow" style=""><span id="MJXc-Node-169" class=
-          "mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-170"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-171"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.003em;">g</span></span><span id="MJXc-Node-172"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-173"
-          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-174"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-175"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-176"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span></span></span></span></span></span>
+          <em>green<sub>8bit</sub> = d<sub>high8bit</sub></em>
         </p>
         <p>
-          <span id="MathJax-Element-9-Frame" class="mjx-chtml"><span id=
-          "MJXc-Node-177" class="mjx-math" role="math"><span id="MJXc-Node-178"
-          class="mjx-mrow"><span id="MJXc-Node-179" class=
-          "mjx-mstyle"><span id="MJXc-Node-180" class="mjx-mrow"><span id=
-          "MJXc-Node-181" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I"
-          style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-182"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">l</span></span><span id="MJXc-Node-183"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">u</span></span><span id="MJXc-Node-184"
-          class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-185"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span></span><span class="mjx-sub"
-          style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-186"
-          class="mjx-mrow" style=""><span id="MJXc-Node-187" class=
-          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-188"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-189"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-190"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-191"
-          class="mjx-mo" style=
-          "padding-left: 0.333em; padding-right: 0.333em;"><span class=
-          "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-192"
-          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">0</span></span></span></span></span></span></span>
+          <em>blue<sub>8bit</sub> = 0</em>
         </p>
         <p>
-          <span id="MathJax-Element-10-Frame" class="mjx-chtml"><span id=
-          "MJXc-Node-193" class="mjx-math" role="math"><span id="MJXc-Node-194"
-          class="mjx-mrow"><span id="MJXc-Node-195" class=
-          "mjx-mstyle"><span id="MJXc-Node-196" class="mjx-mrow"><span id=
-          "MJXc-Node-197" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I"
-          style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-198"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">l</span></span><span id="MJXc-Node-199"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-200"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-201"
-          class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-202"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span></span><span class="mjx-sub"
-          style=
-          "font-size: 70.7%; vertical-align: -0.219em; padding-right: 0.071em;"><span id="MJXc-Node-203"
-          class="mjx-mrow" style=""><span id="MJXc-Node-204" class=
-          "mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">8</span></span><span id="MJXc-Node-205"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">b</span></span><span id="MJXc-Node-206"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.446em; padding-bottom: 0.298em;">i</span></span><span id="MJXc-Node-207"
-          class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style=
-          "padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span></span></span></span><span id="MJXc-Node-208"
-          class="mjx-mo" style=
-          "padding-left: 0.333em; padding-right: 0.333em;"><span class=
-          "mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-209"
-          class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style=
-          "padding-top: 0.372em; padding-bottom: 0.372em;">0</span></span></span></span></span></span></span>
+          <em>alpha<sub>8bit</sub> = 0</em>
         </p>
         <pre class="example highlight">
           var depthVideo = document.querySelector('video');

--- a/index.src.html
+++ b/index.src.html
@@ -345,18 +345,18 @@
           </li>
           <li>Let <var>far</var> be the the <a>far value</a>.
           </li>
-          <li>Apply the <a>rules to convert using range inverse</a> to
-          <var>d</var> to obtain quantized value <var>d<sub>8bit</sub>.</var>
+          <li>Apply the <a>rules to convert using range linear</a> to
+          <var>d</var> to obtain quantized value <var>d<sub>16bit</sub>.</var>
           </li>
           <li>Return <var>d<sub>16bit</sub></var>.
           </li>
         </ol>
         <p>
-          The <dfn>rules to convert using range inverse</dfn> are as given in
+          The <dfn>rules to convert using range linear</dfn> are as given in
           the following formula:
         </p>
         <p>
-          `d_(n) = (far * (d - n ear)) / (d * (far - n ear))`
+          `d_(n) = (d - n ear) / (far - n ear)`
         </p>
         <p>
           `d_(16bit) = floor(d_(n) * 65535)`
@@ -364,7 +364,7 @@
         <div class="note">
           <p>
             The depth measurement <var>d</var> (in meter units) is recovered by
-            solving the <a>rules to convert using range inverse</a> for
+            solving the <a>rules to convert using range linear</a> for
             <var>d</var> as follows:
           </p>
           <ol>
@@ -375,10 +375,10 @@
                 `d_(n) = d_(16bit) / 65535`
               </p>
             </li>
-            <li>Solve the <a>rules to convert using range inverse</a> for <var>
+            <li>Solve the <a>rules to convert using range linear</a> for <var>
               d</var>:
               <p>
-                `d = (far * n ear) / (far - d_(n) * (far - n ear))`
+                `d = (d_(n) * (far - n ear)) + n ear`
               </p>
             </li>
           </ol>
@@ -853,7 +853,6 @@ gl.texImage2D(
   uniform sampler2D u_tex;
   uniform float far;
   uniform float near;
-  uniform bool isRangeInverse;
   void main() {
     vec4 floatColor = texture2D(u_tex, v_texCoord);
     float dn = floatColor.r;
@@ -887,7 +886,7 @@ gl.texImage2D(
         Project Tango for their experiments.
       </p>
       <p>
-        The range inverse format [[!XDM]] is licensed under <a href=
+        The range linear format [[!XDM]] is licensed under <a href=
         "http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.
       </p>
     </section>

--- a/index.src.html
+++ b/index.src.html
@@ -161,23 +161,9 @@
         or <a>depth+video stream</a>.
       </p>
       <p>
-        Depth cameras usually produce 16-bit depth values per pixel. However,
-        neither the canvas drawing surface used to draw and manipulate 2D
-        graphics on the web platform nor the <code><a>ImageData</a></code>
-        interface used to represent image data support 16 bits per pixel. To
-        address the issue, this specification defines a conversion into a 8-bit
-        grayscale representation of a <a>depth map</a> for consumption by APIs
-        that are limited to 8 bits per pixel.
-      </p>
-      <p>
-        The Media Capture Stream with Worker specification
-        [[MEDIACAPTURE-WORKER]] that complements this specification enables
-        processing of 16-bit depth values per pixel directly in a worker
-        environment and makes the <code>&lt;video&gt;</code> and
-        <code>&lt;canvas&gt;</code> indirection and depth-to-grayscale
-        conversion redundant. This alternative pipeline that supports greater
-        bit depth and does not incur the performance penalty of the indirection
-        and conversion enables more advanced use cases.
+        Depth cameras usually produce 16-bit depth values per pixel, so this
+        specification defines a 16-bit grayscale representation of a <a>depth
+        map</a>.
       </p>
     </section>
     <section>
@@ -349,6 +335,54 @@
           view</dfn> which is a double. It represents the vertical angle of
           view in degrees.
         </p>
+        <p>
+          The data type of a <a>depth map</a> is 16-bit unsigned integer. The
+          algorithm to <dfn>convert the depth map value to grayscale</dfn>,
+          given a depth map value <var>d</var>, is as follows:
+        </p>
+        <ol>
+          <li>Let <var>near</var> be the the <a>near value</a>.
+          </li>
+          <li>Let <var>far</var> be the the <a>far value</a>.
+          </li>
+          <li>Apply the <a>rules to convert using range inverse</a> to
+          <var>d</var> to obtain quantized value <var>d<sub>8bit</sub>.</var>
+          </li>
+          <li>Return <var>d<sub>16bit</sub></var>.
+          </li>
+        </ol>
+        <p>
+          The <dfn>rules to convert using range inverse</dfn> are as given in
+          the following formula:
+        </p>
+        <p>
+          `d_(n) = (far * (d - n ear)) / (d * (far - n ear))`
+        </p>
+        <p>
+          `d_(16bit) = floor(d_(n) * 65535)`
+        </p>
+        <div class="note">
+          <p>
+            The depth measurement <var>d</var> (in meter units) is recovered by
+            solving the <a>rules to convert using range inverse</a> for
+            <var>d</var> as follows:
+          </p>
+          <ol>
+            <li>Given <var>d<sub>16bit</sub></var>, <var>near</var> <a>near
+            value</a> and <var>far</var> <a>far value</a>, normalize
+            <var>d<sub>16bit</sub></var> to [0, 1] range:
+              <p>
+                `d_(n) = d_(16bit) / 65535`
+              </p>
+            </li>
+            <li>Solve the <a>rules to convert using range inverse</a> for <var>
+              d</var>:
+              <p>
+                `d = (far * n ear) / (far - d_(n) * (far - n ear))`
+              </p>
+            </li>
+          </ol>
+        </div>
       </section>
     </section>
     <section>
@@ -433,6 +467,25 @@
             requirements, since it might not be possible to synchronize tracks
             from sources.
           </p>
+          <p>
+            There are two ways to access the 16 bit depth values.
+          </p>
+          <ol>
+            <li>
+              <code>16bit</code> texture in [[WEBGL]] after uploading a
+              <a>depth map</a> to the texture. For instance, <code>RGB</code>
+              and <code>LUMINANCE_ALPHA</code> are <code>16bit</code> texture.
+            </li>
+            <li>the Media Capture Stream with Worker specification
+            [[MEDIACAPTURE-WORKER]] that complements this specification enables
+            processing of 16-bit depth values per pixel directly in a worker
+            environment and makes the <code>&lt;video&gt;</code> and
+            <code>&lt;canvas&gt;</code> indirection and depth-to-grayscale
+            conversion redundant. This alternative pipeline that supports
+            greater bit depth and does not incur the performance penalty of the
+            indirection and conversion enables more advanced use cases.
+            </li>
+          </ol>
         </section>
       </section>
       <section>
@@ -512,51 +565,16 @@
           playing</a>.
         </p>
         <p>
-          The algorithm to <dfn>convert the depth map value to grayscale</dfn>,
-          given a depth map value <var>d</var>, is as follows:
-        </p>
-        <ol>
-          <li>Let <var>near</var> be the the <a>near value</a>.
-          </li>
-          <li>Let <var>far</var> be the the <a>far value</a>.
-          </li>
-          <li>Apply the <a>rules to convert using range inverse</a> to
-          <var>d</var> to obtain quantized value <var>d<sub>8bit</sub>.</var>
-          </li>
-          <li>Return <var>d<sub>8bit</sub></var>.
-          </li>
-        </ol>
-        <p>
-          The <dfn>rules to convert using range inverse</dfn> are as given in
-          the following formula:
+          The <code>video</code> element draws the depth map after conversion
+          as follows:
         </p>
         <p>
-          `d_(n) = (far * (d - n ear)) / (d * (far - n ear))`
-        </p>
-        <p>
-          `d_(8bit) = floor(d_(n) * 255)`
+          `red_(8bit) = d_(16bit) / 255`
         </p>
         <div class="note">
-          <p>
-            The depth measurement <var>d</var> (in meter units) is recovered by
-            solving the <a>rules to convert using range inverse</a> for
-            <var>d</var> as follows:
-          </p>
-          <ol>
-            <li>Given <var>d<sub>8bit</sub></var>, <var>near</var> <a>near
-            value</a> and <var>far</var> <a>far value</a>, normalize
-            <var>d<sub>8bit</sub></var> to [0, 1] range:
-              <p>
-                `d_(n) = d_(8bit) / 255`
-              </p>
-            </li>
-            <li>Solve the <a>rules to convert using range inverse</a> for <var>
-              d</var>:
-              <p>
-                `d = (far * n ear) / (far - d_(n) * (far - n ear))`
-              </p>
-            </li>
-          </ol>
+          It is an implementation detail how the frames are rendered to the
+          screen. For example, the implementation may use a grayscale or red
+          channel representation.
         </div>
         <section>
           <h2>

--- a/index.src.html
+++ b/index.src.html
@@ -588,9 +588,9 @@
           data</a> represents a <a>depth map</a>), its <a>Uint8ClampedArray</a>
           source assigned to the <a>data</a> attribute represents the
           <dfn>16-bit depth value</dfn> by assigning the low 8-bit of the
-          <a>16-bit depth value</a> `d_(low8bit)` on its red component, and
-          high 8-bit of the <a>16-bit depth value</a> `d_(high8bit)` on its
-          green component.
+          <a>16-bit depth value</a> <em>d<sub>low8bit</sub></em> on its red
+          component, and high 8-bit of the <a>16-bit depth value</a>
+          <em>d<sub>high8bit</sub></em> on its green component.
         </p>
         <p>
           If the values are read from the default <a>Uint8ClampedArray</a>
@@ -598,16 +598,16 @@
           <code>ArrayBuffer</code></a> data as follows:
         </p>
         <p>
-          `red_(8bit) = d_(low8bit)`
+          <em>red<sub>8bit</sub> = d<sub>low8bit</sub></em>
         </p>
         <p>
-          `green_(8bit) = d_(high8bit)`
+          <em>green<sub>8bit</sub> = d<sub>high8bit</sub></em>
         </p>
         <p>
-          `blue_(8bit) = 0`
+          <em>blue<sub>8bit</sub> = 0</em>
         </p>
         <p>
-          `a lpha_(8bit) = 0`
+          <em>alpha<sub>8bit</sub> = 0</em>
         </p>
         <pre class="example highlight">
           var depthVideo = document.querySelector('video');

--- a/index.src.html
+++ b/index.src.html
@@ -257,10 +257,35 @@
       </p>
       <p>
         The <code><a href=
-        "https://html.spec.whatwg.org/#imagedata"><dfn>ImageData</dfn></a></code>
-        and <code><a href=
-        "https://html.spec.whatwg.org/#videotrack"><dfn>VideoTrack</dfn></a></code>
-        interfaces are defined in [[!HTML]].
+        "https://html.spec.whatwg.org/multipage/embedded-content.html#the-video-element">
+        <dfn>video</dfn></a></code> element and <code><a href=
+        "https://html.spec.whatwg.org/multipage/scripting.html#imagedata"><dfn>ImageData</dfn></a></code>
+        (and its <code><a href=
+        "%20https://html.spec.whatwg.org/multipage/scripting.html#dom-imagedata-data">
+        <dfn>data</dfn></a></code> attribute and <a href=
+        "https://html.spec.whatwg.org/multipage/scripting.html#canvas-pixel-arraybuffer">
+        <dfn>Canvas Pixel <code>ArrayBuffer</code></dfn></a>), <code><a href=
+        "https://html.spec.whatwg.org/multipage/embedded-content.html#videotrack">
+        <dfn>VideoTrack</dfn></a></code>, <code><a href=
+        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">
+        <dfn>HTMLMediaElement</dfn></a></code> (and its <code><a href=
+        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-srcobject">
+        <dfn>srcObject</dfn></a></code> attribute), <code><a href=
+        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#htmlvideoelement">
+        <dfn>HTMLVideoElement</dfn></a></code> interfaces and the
+        <code><a href="%20https://html.spec.whatwg.org/multipage/scripting.html#canvasimagesource">
+        <dfn>CanvasImageSource</dfn></a></code> enum are defined in [[!HTML]].
+      </p>
+      <p>
+        The terms <a href=
+        "https://html.spec.whatwg.org/multipage/embedded-content.html#media-data">
+        <dfn>media data</dfn></a>, <a href=
+        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#media-provider-object">
+        <dfn>media provider object</dfn></a> , <a href=
+        "https://html.spec.whatwg.org/multipage/embedded-content.html#assigned-media-provider-object">
+        <dfn>assigned media provider object</dfn></a>, and the concept <a href=
+        "https://html.spec.whatwg.org/multipage/embedded-content.html#potentially-playing">
+        <dfn>potentially playing</dfn></a> are defined in [[!HTML]].
       </p>
       <p>
         The term <a href=
@@ -268,6 +293,15 @@
         and the permission name <code><a href=
         "https://w3c.github.io/permissions/#dom-permissionname-camera">"<dfn>camera</dfn>"</a></code>
         are defined in [[!PERMISSIONS]].
+      </p>
+      <p>
+        The <code><a href=
+        "http://heycam.github.io/webidl/#idl-DataView"><dfn>DataView</dfn></a></code>,
+        <code><a href=
+        "http://heycam.github.io/webidl/#idl-Uint8ClampedArray"><dfn>Uint8ClampedArray</dfn></a></code>,
+        and <code><a href=
+        "http://heycam.github.io/webidl/#idl-Uint16Array"><dfn>Uint16Array</dfn></a></code>
+        buffer source types are defined in [[WEBIDL]].
       </p>
     </section>
     <section>
@@ -338,7 +372,7 @@
         <p>
           The data type of a <a>depth map</a> is 16-bit unsigned integer. The
           algorithm to <dfn>convert the depth map value to grayscale</dfn>,
-          given a depth map value <var>d</var>, is as follows:
+          given a <dfn>depth map value</dfn> <var>d</var>, is as follows:
         </p>
         <ol>
           <li>Let <var>near</var> be the the <a>near value</a>.
@@ -467,25 +501,6 @@
             requirements, since it might not be possible to synchronize tracks
             from sources.
           </p>
-          <p>
-            There are two ways to access the 16 bit depth values.
-          </p>
-          <ol>
-            <li>
-              <code>16bit</code> texture in [[WEBGL]] after uploading a
-              <a>depth map</a> to the texture. For instance, <code>RGB</code>
-              and <code>LUMINANCE_ALPHA</code> are <code>16bit</code> texture.
-            </li>
-            <li>the Media Capture Stream with Worker specification
-            [[MEDIACAPTURE-WORKER]] that complements this specification enables
-            processing of 16-bit depth values per pixel directly in a worker
-            environment and makes the <code>&lt;video&gt;</code> and
-            <code>&lt;canvas&gt;</code> indirection and depth-to-grayscale
-            conversion redundant. This alternative pipeline that supports
-            greater bit depth and does not incur the performance penalty of the
-            indirection and conversion enables more advanced use cases.
-            </li>
-          </ol>
         </section>
       </section>
       <section>
@@ -517,22 +532,14 @@
           Media provider object
         </h2>
         <p>
-          A <a href="https://html.spec.whatwg.org/#media-provider-object">media
-          provider object</a> can represent a <a>depth-only stream</a> (and
-          specifically, not a <a>depth+video stream</a>). The <a>user agent</a>
-          MUST support a <a href=
-          "https://html.spec.whatwg.org/#media-element">media element</a> with
-          an <a href=
-          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
-          media provider object</a> that is a <a>depth-only stream</a>, and in
-          particular, the <a href=
-          "https://html.spec.whatwg.org/#dom-media-srcobject"><code>srcObject</code></a>
-          IDL attribute that allows the <a href=
-          "https://html.spec.whatwg.org/#media-element">media element</a> to be
-          assigned a <a href=
-          "https://html.spec.whatwg.org/#media-provider-object">media provider
-          object</a> MUST, on setting and getting, behave as specified in
-          [[!HTML]].
+          A <a>media provider object</a> can represent a <a>depth-only
+          stream</a> (and specifically, not a <a>depth+video stream</a>). The
+          <a>user agent</a> MUST support a <a>HTMLMediaElement</a> with an
+          <a>assigned media provider object</a> that is a <a>depth-only
+          stream</a>, and in particular, the <a>srcObject</a> IDL attribute
+          that allows the <a>HTMLMediaElement</a> to be assigned a <a>media
+          provider object</a> MUST, on setting and getting, behave as specified
+          in [[!HTML]].
         </p>
       </section>
       <section>
@@ -540,42 +547,25 @@
           The <code>video</code> element
         </h2>
         <p>
-          For a <a href=
-          "https://html.spec.whatwg.org/#the-video-element"><code>video</code>
-          element</a> whose <a href=
-          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
-          media provider object</a> is a <a>depth-only stream</a>, the <a>user
-          agent</a> MUST, for each pixel of the <a href=
-          "https://html.spec.whatwg.org/#media-data">media data</a> that is
-          represented by a <a>depth map</a>, <a>convert the depth map value to
-          grayscale</a> prior to when the <code>video</code> element is
-          <a href="https://html.spec.whatwg.org/#potentially-playing">potentially
-          playing</a>.
-        </p>
-        <p>
-          For a <a href=
-          "https://html.spec.whatwg.org/#the-video-element"><code>video</code>
-          element</a> whose <a href=
-          "https://html.spec.whatwg.org/#assigned-media-provider-object">assigned
-          media provider object</a> is a <a>depth+video stream</a>, the <a>user
-          agent</a> MUST act as if all the <a>MediaStreamTrack</a>s of kind
-          "<code>depth</code>" were removed prior to when the
-          <code>video</code> element is <a href=
-          "https://html.spec.whatwg.org/#potentially-playing">potentially
-          playing</a>.
-        </p>
-        <p>
-          The <code>video</code> element draws the depth map after conversion
-          as follows:
-        </p>
-        <p>
-          `red_(8bit) = d_(16bit) / 255`
+          When a <a>video</a> element is <a>potentially playing</a> and its
+          <a>assigned media provider object</a> is a <a>depth-only stream</a>,
+          the <a>user agent</a> MUST, for each pixel of the <a>media data</a>
+          that is represented by a <a>depth map</a>, given a depth map value
+          <em>d</em>, <a>convert the depth map value to grayscale</a> and
+          render the returned value to the screen.
         </p>
         <div class="note">
           It is an implementation detail how the frames are rendered to the
           screen. For example, the implementation may use a grayscale or red
-          channel representation.
+          representation, with either 8-bit or 16-bit precision.
         </div>
+        <p>
+          For a <a>video</a> element whose <a>assigned media provider
+          object</a> is a <a>depth+video stream</a>, the <a>user agent</a> MUST
+          act as if all the <a>MediaStreamTrack</a>s of kind
+          "<code>depth</code>" were removed prior to when the
+          <code>video</code> element is <a>potentially playing</a>.
+        </p>
         <section>
           <h2>
             <code>VideoTrack</code> interface
@@ -586,6 +576,64 @@
             as defined in [[HTML]].
           </p>
         </section>
+      </section>
+      <section>
+        <h2>
+          <code>ImageData</code> interface
+        </h2>
+        <p>
+          When an <a>ImageData</a> object's pixel values represent a <a>depth
+          map</a> (that is, the image source for the 2D rendering context
+          <a>CanvasImageSource</a> is a <a>HTMLVideoElement</a> whose <a>media
+          data</a> represents a <a>depth map</a>), its <a>Uint8ClampedArray</a>
+          source assigned to the <a>data</a> attribute represents the
+          <dfn>16-bit depth value</dfn> by assigning the low 8-bit of the
+          <a>16-bit depth value</a> `d_(low8bit)` on its red component, and
+          high 8-bit of the <a>16-bit depth value</a> `d_(high8bit)` on its
+          green component.
+        </p>
+        <p>
+          If the values are read from the default <a>Uint8ClampedArray</a>
+          view, they are represented as <a>Canvas Pixel
+          <code>ArrayBuffer</code></a> data as follows:
+        </p>
+        <p>
+          `red_(8bit) = d_(low8bit)`
+        </p>
+        <p>
+          `green_(8bit) = d_(high8bit)`
+        </p>
+        <p>
+          `blue_(8bit) = 0`
+        </p>
+        <p>
+          `a lpha_(8bit) = 0`
+        </p>
+        <pre class="example highlight">
+          var depthVideo = document.querySelector('video');
+          var canvas = document.querySelector('canvas');
+          var context = canvas.getContext('2d');
+          var w = depthVideo.videoWidth, h = depthVideo.videoHeight;
+
+          context.drawImage(depthVideo, 0, 0, w, h);
+          var imageData = context.getImageData(0, 0, w, h);
+
+          // Create a new DataView dv on to an ArrayBuffer buffer
+          // that exposes it as an array of unsigned 16-bit integers.
+          var dv = new DataView(imageData.data.buffer);
+
+          // Read every fourth unsigned 16-bit value in little endian representation.
+          for (var i = 0; i &lt; imageData.data.length; i += 4) {
+            console.log(dv.getUint16(i, true));
+          }
+
+          // Alternatively, reconstruct unsigned 16-bit value. The result
+          // is the same as if DataView and getUint16() was used.
+          for (var i = 0; i &lt; imageData.data.length; i += 4) {
+            console.log(imageData.data[i] + (imageData.data[i+1] &lt;&lt; 8));
+          }
+        
+</pre>
       </section>
       <section>
         <h2>
@@ -775,6 +823,9 @@
           <h3>
             Implementation considerations
           </h3>
+          <div class="note">
+            This section is currently work in progress, and subject to change.
+          </div>
           <p>
             A <code>video</code> element whose source is a
             <a><code>MediaStream</code></a> object containing a <a>depth stream


### PR DESCRIPTION
In #125, I proposed 
1. explicitly define 16-bit integer as depth type
2. explicitly declare this spec depends on WebGL2

Our friends agreed, so let me propose this PR.

Fix #125: define the data type of a depth map is 16-bit unsigned integer.
Fix #125: explicitly declare this spec depends on WebGL2.
