### PR TITLE
Use data-cite for automatic cross-referencing

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,108 +245,90 @@
         Dependencies
       </h2>
       <p>
-        The <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaStreamTrack">
-        <dfn>MediaStreamTrack</dfn></a></code> and <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaStream">
-        <dfn>MediaStream</dfn></a></code> interfaces this specification extends
-        are defined in [[!GETUSERMEDIA]].
+        The <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaStreamTrack">MediaStreamTrack</dfn></code>
+        and <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaStream">MediaStream</dfn></code> interfaces
+        this specification extends are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-Constraints">
-        <dfn>Constraints</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaTrackSettings">
-        <dfn>MediaTrackSettings</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaTrackConstraints">
-        <dfn>MediaTrackConstraints</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaTrackSupportedConstraints">
-        <dfn>MediaTrackSupportedConstraints</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaTrackCapabilities">
-        <dfn>MediaTrackCapabilities</dfn></a></code>, and <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaTrackConstraintSet">
-        <dfn>MediaTrackConstraintSet</dfn></a></code> dictionaries this
-        specification extends are defined in [[!GETUSERMEDIA]].
-      </p>
-      <p>
-        The <code><a href=
-        "https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia">
-        <dfn>getUserMedia()</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/#dfn-getsettings"><dfn>getSettings()</dfn></a></code>
-        methods and the <code><a href=
-        "https://w3c.github.io/mediacapture-main/#idl-def-NavigatorUserMediaSuccessCallback">
-        <dfn>NavigatorUserMediaSuccessCallback</dfn></a></code> callback are
-        defined in [[!GETUSERMEDIA]].
-      </p>
-      <p>
-        The concepts <a href=
-        "https://w3c.github.io/mediacapture-main/#track-muted"><dfn>muted</dfn></a>,
-        <a href=
-        "https://w3c.github.io/mediacapture-main/#track-enabled"><dfn>disabled</dfn></a>,
-        and <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#event-mediastreamtrack-overconstrained">
-        <dfn>overconstrained</dfn></a></code> as applied to
-        <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
-      </p>
-      <p>
-        The terms <a href=
-        "https://w3c.github.io/mediacapture-main/#dfn-source"><dfn>source</dfn></a>
-        and <a href=
-        "https://w3c.github.io/mediacapture-main/#dfn-consumer"><dfn>consumer</dfn></a>
-        are defined in [[!GETUSERMEDIA]].
-      </p>
-      <p>
-        The <code><a href=
-        "https://w3c.github.io/mediacapture-main/#idl-def-MediaDeviceKind"><dfn>
-        MediaDeviceKind</dfn></a></code> enumeration is defined in
+        The <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-Constraints">Constraints</dfn></code>,
+        <code><dfn data-cite=
+        "GETUSERMEDIA#idl-def-MediaTrackSettings">MediaTrackSettings</dfn></code>,
+        <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaTrackConstraints">MediaTrackConstraints</dfn></code>,
+        <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaTrackSupportedConstraints">MediaTrackSupportedConstraints</dfn></code>,
+        <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaTrackCapabilities">MediaTrackCapabilities</dfn></code>,
+        and <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaTrackConstraintSet">MediaTrackConstraintSet</dfn></code>
+        dictionaries this specification extends are defined in
         [[!GETUSERMEDIA]].
       </p>
       <p>
-        The <code><a href=
-        "https://html.spec.whatwg.org/multipage/embedded-content.html#the-video-element">
-        <dfn>video</dfn></a></code> element and <code><a href=
-        "https://html.spec.whatwg.org/multipage/scripting.html#imagedata"><dfn>ImageData</dfn></a></code>
-        (and its <code><a href=
-        "%20https://html.spec.whatwg.org/multipage/scripting.html#dom-imagedata-data">
-        <dfn>data</dfn></a></code> attribute and <a href=
-        "https://html.spec.whatwg.org/multipage/scripting.html#canvas-pixel-arraybuffer">
-        <dfn>Canvas Pixel <code>ArrayBuffer</code></dfn></a>), <code><a href=
-        "https://html.spec.whatwg.org/multipage/embedded-content.html#videotrack">
-        <dfn>VideoTrack</dfn></a></code>, <code><a href=
-        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">
-        <dfn>HTMLMediaElement</dfn></a></code> (and its <code><a href=
-        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-srcobject">
-        <dfn>srcObject</dfn></a></code> attribute), <code><a href=
-        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#htmlvideoelement">
-        <dfn>HTMLVideoElement</dfn></a></code> interfaces and the
-        <code><a href="%20https://html.spec.whatwg.org/multipage/scripting.html#canvasimagesource">
-        <dfn>CanvasImageSource</dfn></a></code> enum are defined in [[!HTML]].
+        The <code><dfn data-cite=
+        "!GETUSERMEDIA#dom-mediadevices-getusermedia">getUserMedia()</dfn></code>,
+        <code><dfn data-cite=
+        "!GETUSERMEDIA#dfn-getsettings">getSettings()</dfn></code> methods and
+        the <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-NavigatorUserMediaSuccessCallback">NavigatorUserMediaSuccessCallback</dfn></code>
+        callback are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The terms <a href=
-        "https://html.spec.whatwg.org/multipage/embedded-content.html#media-data">
-        <dfn>media data</dfn></a>, <a href=
-        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#media-provider-object">
-        <dfn>media provider object</dfn></a> , <a href=
-        "https://html.spec.whatwg.org/multipage/embedded-content.html#assigned-media-provider-object">
-        <dfn>assigned media provider object</dfn></a>, and the concept <a href=
-        "https://html.spec.whatwg.org/multipage/embedded-content.html#potentially-playing">
-        <dfn>potentially playing</dfn></a> are defined in [[!HTML]].
+        The concepts <dfn data-cite="!GETUSERMEDIA#track-muted">muted</dfn>,
+        <dfn data-cite="!GETUSERMEDIA#track-enabled">disabled</dfn>, and
+        <code><dfn data-cite=
+        "!GETUSERMEDIA#event-mediastreamtrack-overconstrained">overconstrained</dfn></code>
+        as applied to <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The term <a href=
-        "https://w3c.github.io/permissions/#permission"><dfn>permission</dfn></a>
-        and the permission name <code><a href=
-        "https://w3c.github.io/permissions/#dom-permissionname-camera">"<dfn>camera</dfn>"</a></code>
-        are defined in [[!PERMISSIONS]].
+        The terms <dfn data-cite="!GETUSERMEDIA#dfn-source">source</dfn> and
+        <dfn data-cite="!GETUSERMEDIA#dfn-consumer">consumer</dfn> are defined
+        in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The <code><a href=
-        "https://heycam.github.io/webidl/#idl-DataView"><dfn>DataView</dfn></a></code>,
-        <code><a href=
-        "https://heycam.github.io/webidl/#idl-Uint8ClampedArray"><dfn>Uint8ClampedArray</dfn></a></code>,
-        and <code><a href=
-        "https://heycam.github.io/webidl/#idl-Uint16Array"><dfn>Uint16Array</dfn></a></code>
+        The <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaDeviceKind">MediaDeviceKind</dfn></code>
+        enumeration is defined in [[!GETUSERMEDIA]].
+      </p>
+      <p>
+        The <code><dfn data-cite="!HTML#the-video-element">video</dfn></code>
+        element and <code><dfn data-cite=
+        "!HTML#imagedata">ImageData</dfn></code> (and its <code><dfn data-cite=
+        "!HTML#dom-imagedata-data">data</dfn></code> attribute and
+        <dfn data-cite="!HTML#canvas-pixel-arraybuffer">Canvas Pixel
+        <code>ArrayBuffer</code></dfn>), <code><dfn data-cite=
+        "!HTML#videotrack">VideoTrack</dfn></code>, <code><dfn data-cite=
+        "!HTML#htmlmediaelement">HTMLMediaElement</dfn></code> (and its
+        <code><dfn data-cite="!HTML#dom-media-srcobject">srcObject</dfn></code>
+        attribute), <code><dfn data-cite=
+        "!HTML#htmlvideoelement">HTMLVideoElement</dfn></code> interfaces and
+        the <code><dfn data-cite=
+        "!HTML#canvasimagesource">CanvasImageSource</dfn></code> enum are
+        defined in [[!HTML]].
+      </p>
+      <p>
+        The terms <dfn data-cite="!HTML#media-data">media data</dfn>,
+        <dfn data-cite="!HTML#media-provider-object">media provider
+        object</dfn>, <dfn data-cite=
+        "!HTML#assigned-media-provider-object">assigned media provider
+        object</dfn>, and the concept <dfn data-cite=
+        "!HTML#potentially-playing">potentially playing</dfn> are defined in
+        [[!HTML]].
+      </p>
+      <p>
+        The term <dfn data-cite="!PERMISSIONS#permission">permission</dfn> and
+        the permission name <code>"<dfn data-cite=
+        "!PERMISSIONS#dom-permissionname-camera">camera</dfn>"</code> are
+        defined in [[!PERMISSIONS]].
+      </p>
+      <p>
+        The <code><dfn data-cite="!WEBIDL#idl-DataView">DataView</dfn></code>,
+        <code><dfn data-cite=
+        "!WEBIDL#idl-Uint8ClampedArray">Uint8ClampedArray</dfn></code>, and
+        <code><dfn data-cite="!WEBIDL#idl-Uint16Array">Uint16Array</dfn></code>
         buffer source types are defined in [[WEBIDL]].
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -1259,7 +1259,6 @@ gl.texImage2D(
         to Ningxin Hu for experimental implementations, as well as to the
         Project Tango for their experiments.
       </p>
-    </section>
-    <section id="idl-index" class="appendix"></section>
+    </section><!--section id="idl-index" class="appendix"></section-->
   </body>
 </html>

--- a/index.src.html
+++ b/index.src.html
@@ -180,108 +180,90 @@
         Dependencies
       </h2>
       <p>
-        The <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaStreamTrack">
-        <dfn>MediaStreamTrack</dfn></a></code> and <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaStream">
-        <dfn>MediaStream</dfn></a></code> interfaces this specification extends
-        are defined in [[!GETUSERMEDIA]].
+        The <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaStreamTrack">MediaStreamTrack</dfn></code>
+        and <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaStream">MediaStream</dfn></code> interfaces
+        this specification extends are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-Constraints">
-        <dfn>Constraints</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaTrackSettings">
-        <dfn>MediaTrackSettings</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaTrackConstraints">
-        <dfn>MediaTrackConstraints</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaTrackSupportedConstraints">
-        <dfn>MediaTrackSupportedConstraints</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaTrackCapabilities">
-        <dfn>MediaTrackCapabilities</dfn></a></code>, and <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#idl-def-MediaTrackConstraintSet">
-        <dfn>MediaTrackConstraintSet</dfn></a></code> dictionaries this
-        specification extends are defined in [[!GETUSERMEDIA]].
-      </p>
-      <p>
-        The <code><a href=
-        "https://w3c.github.io/mediacapture-main/#dom-mediadevices-getusermedia">
-        <dfn>getUserMedia()</dfn></a></code>, <code><a href=
-        "https://w3c.github.io/mediacapture-main/#dfn-getsettings"><dfn>getSettings()</dfn></a></code>
-        methods and the <code><a href=
-        "https://w3c.github.io/mediacapture-main/#idl-def-NavigatorUserMediaSuccessCallback">
-        <dfn>NavigatorUserMediaSuccessCallback</dfn></a></code> callback are
-        defined in [[!GETUSERMEDIA]].
-      </p>
-      <p>
-        The concepts <a href=
-        "https://w3c.github.io/mediacapture-main/#track-muted"><dfn>muted</dfn></a>,
-        <a href=
-        "https://w3c.github.io/mediacapture-main/#track-enabled"><dfn>disabled</dfn></a>,
-        and <code><a href=
-        "https://w3c.github.io/mediacapture-main/archives/20160513/getusermedia.html#event-mediastreamtrack-overconstrained">
-        <dfn>overconstrained</dfn></a></code> as applied to
-        <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
-      </p>
-      <p>
-        The terms <a href=
-        "https://w3c.github.io/mediacapture-main/#dfn-source"><dfn>source</dfn></a>
-        and <a href=
-        "https://w3c.github.io/mediacapture-main/#dfn-consumer"><dfn>consumer</dfn></a>
-        are defined in [[!GETUSERMEDIA]].
-      </p>
-      <p>
-        The <code><a href=
-        "https://w3c.github.io/mediacapture-main/#idl-def-MediaDeviceKind"><dfn>
-        MediaDeviceKind</dfn></a></code> enumeration is defined in
+        The <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-Constraints">Constraints</dfn></code>,
+        <code><dfn data-cite=
+        "GETUSERMEDIA#idl-def-MediaTrackSettings">MediaTrackSettings</dfn></code>,
+        <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaTrackConstraints">MediaTrackConstraints</dfn></code>,
+        <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaTrackSupportedConstraints">MediaTrackSupportedConstraints</dfn></code>,
+        <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaTrackCapabilities">MediaTrackCapabilities</dfn></code>,
+        and <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaTrackConstraintSet">MediaTrackConstraintSet</dfn></code>
+        dictionaries this specification extends are defined in
         [[!GETUSERMEDIA]].
       </p>
       <p>
-        The <code><a href=
-        "https://html.spec.whatwg.org/multipage/embedded-content.html#the-video-element">
-        <dfn>video</dfn></a></code> element and <code><a href=
-        "https://html.spec.whatwg.org/multipage/scripting.html#imagedata"><dfn>ImageData</dfn></a></code>
-        (and its <code><a href=
-        "%20https://html.spec.whatwg.org/multipage/scripting.html#dom-imagedata-data">
-        <dfn>data</dfn></a></code> attribute and <a href=
-        "https://html.spec.whatwg.org/multipage/scripting.html#canvas-pixel-arraybuffer">
-        <dfn>Canvas Pixel <code>ArrayBuffer</code></dfn></a>), <code><a href=
-        "https://html.spec.whatwg.org/multipage/embedded-content.html#videotrack">
-        <dfn>VideoTrack</dfn></a></code>, <code><a href=
-        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement">
-        <dfn>HTMLMediaElement</dfn></a></code> (and its <code><a href=
-        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-srcobject">
-        <dfn>srcObject</dfn></a></code> attribute), <code><a href=
-        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#htmlvideoelement">
-        <dfn>HTMLVideoElement</dfn></a></code> interfaces and the
-        <code><a href="%20https://html.spec.whatwg.org/multipage/scripting.html#canvasimagesource">
-        <dfn>CanvasImageSource</dfn></a></code> enum are defined in [[!HTML]].
+        The <code><dfn data-cite=
+        "!GETUSERMEDIA#dom-mediadevices-getusermedia">getUserMedia()</dfn></code>,
+        <code><dfn data-cite=
+        "!GETUSERMEDIA#dfn-getsettings">getSettings()</dfn></code> methods and
+        the <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-NavigatorUserMediaSuccessCallback">NavigatorUserMediaSuccessCallback</dfn></code>
+        callback are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The terms <a href=
-        "https://html.spec.whatwg.org/multipage/embedded-content.html#media-data">
-        <dfn>media data</dfn></a>, <a href=
-        "%20https://html.spec.whatwg.org/multipage/embedded-content.html#media-provider-object">
-        <dfn>media provider object</dfn></a> , <a href=
-        "https://html.spec.whatwg.org/multipage/embedded-content.html#assigned-media-provider-object">
-        <dfn>assigned media provider object</dfn></a>, and the concept <a href=
-        "https://html.spec.whatwg.org/multipage/embedded-content.html#potentially-playing">
-        <dfn>potentially playing</dfn></a> are defined in [[!HTML]].
+        The concepts <dfn data-cite="!GETUSERMEDIA#track-muted">muted</dfn>,
+        <dfn data-cite="!GETUSERMEDIA#track-enabled">disabled</dfn>, and
+        <code><dfn data-cite=
+        "!GETUSERMEDIA#event-mediastreamtrack-overconstrained">overconstrained</dfn></code>
+        as applied to <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The term <a href=
-        "https://w3c.github.io/permissions/#permission"><dfn>permission</dfn></a>
-        and the permission name <code><a href=
-        "https://w3c.github.io/permissions/#dom-permissionname-camera">"<dfn>camera</dfn>"</a></code>
-        are defined in [[!PERMISSIONS]].
+        The terms <dfn data-cite="!GETUSERMEDIA#dfn-source">source</dfn> and
+        <dfn data-cite="!GETUSERMEDIA#dfn-consumer">consumer</dfn> are defined
+        in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The <code><a href=
-        "https://heycam.github.io/webidl/#idl-DataView"><dfn>DataView</dfn></a></code>,
-        <code><a href=
-        "https://heycam.github.io/webidl/#idl-Uint8ClampedArray"><dfn>Uint8ClampedArray</dfn></a></code>,
-        and <code><a href=
-        "https://heycam.github.io/webidl/#idl-Uint16Array"><dfn>Uint16Array</dfn></a></code>
+        The <code><dfn data-cite=
+        "!GETUSERMEDIA#idl-def-MediaDeviceKind">MediaDeviceKind</dfn></code>
+        enumeration is defined in [[!GETUSERMEDIA]].
+      </p>
+      <p>
+        The <code><dfn data-cite="!HTML#the-video-element">video</dfn></code>
+        element and <code><dfn data-cite=
+        "!HTML#imagedata">ImageData</dfn></code> (and its <code><dfn data-cite=
+        "!HTML#dom-imagedata-data">data</dfn></code> attribute and
+        <dfn data-cite="!HTML#canvas-pixel-arraybuffer">Canvas Pixel
+        <code>ArrayBuffer</code></dfn>), <code><dfn data-cite=
+        "!HTML#videotrack">VideoTrack</dfn></code>, <code><dfn data-cite=
+        "!HTML#htmlmediaelement">HTMLMediaElement</dfn></code> (and its
+        <code><dfn data-cite="!HTML#dom-media-srcobject">srcObject</dfn></code>
+        attribute), <code><dfn data-cite=
+        "!HTML#htmlvideoelement">HTMLVideoElement</dfn></code> interfaces and
+        the <code><dfn data-cite=
+        "!HTML#canvasimagesource">CanvasImageSource</dfn></code> enum are
+        defined in [[!HTML]].
+      </p>
+      <p>
+        The terms <dfn data-cite="!HTML#media-data">media data</dfn>,
+        <dfn data-cite="!HTML#media-provider-object">media provider
+        object</dfn>, <dfn data-cite=
+        "!HTML#assigned-media-provider-object">assigned media provider
+        object</dfn>, and the concept <dfn data-cite=
+        "!HTML#potentially-playing">potentially playing</dfn> are defined in
+        [[!HTML]].
+      </p>
+      <p>
+        The term <dfn data-cite="!PERMISSIONS#permission">permission</dfn> and
+        the permission name <code>"<dfn data-cite=
+        "!PERMISSIONS#dom-permissionname-camera">camera</dfn>"</code> are
+        defined in [[!PERMISSIONS]].
+      </p>
+      <p>
+        The <code><dfn data-cite="!WEBIDL#idl-DataView">DataView</dfn></code>,
+        <code><dfn data-cite=
+        "!WEBIDL#idl-Uint8ClampedArray">Uint8ClampedArray</dfn></code>, and
+        <code><dfn data-cite="!WEBIDL#idl-Uint16Array">Uint16Array</dfn></code>
         buffer source types are defined in [[WEBIDL]].
       </p>
     </section>

--- a/index.src.html
+++ b/index.src.html
@@ -991,7 +991,6 @@ gl.texImage2D(
         to Ningxin Hu for experimental implementations, as well as to the
         Project Tango for their experiments.
       </p>
-    </section>
-    <section id="idl-index" class="appendix"></section>
+    </section><!--section id="idl-index" class="appendix"></section-->
   </body>
 </html>


### PR DESCRIPTION
Use data-cite ReSpec feature for automatic cross-referencing:
https://lists.w3.org/Archives/Public/spec-prod/2017JanMar/0011.html

This feature was very much welcome for this spec that had a long list of dependencies. Thanks @marcoscaceres! 