### PR TITLE
Fix depthToVideoTransform type

### DIFF
--- a/index.html
+++ b/index.html
@@ -619,7 +619,7 @@
               double              principalPointY;
               DistortionCoefficients deprojectionDistortionCoefficients;
               DistortionCoefficients projectionDistortionCoefficients;
-              Transform depthToVideoTransform;
+              Transformation      depthToVideoTransform;
           };
 
           dictionary DistortionCoefficients {

--- a/index.src.html
+++ b/index.src.html
@@ -542,7 +542,7 @@
               double              principalPointY;
               DistortionCoefficients deprojectionDistortionCoefficients;
               DistortionCoefficients projectionDistortionCoefficients;
-              Transform depthToVideoTransform;
+              Transformation      depthToVideoTransform;
           };
 
           dictionary DistortionCoefficients {


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/mediacapture-depth/depthToVideoTransform.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/mediacapture-depth/3709194...953ed58.html)