### PR TITLE
Fix ReSpec warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -796,7 +796,8 @@
           </p>
           <p>
             The <a>MediaStream</a> <a>consumer</a> for the <a>depth-only
-            stream</a> and <a>depth+color stream</a> is <a href="#the-video-element">the <code>video</code> element</a> [[!HTML]].
+            stream</a> and <a>depth+color stream</a> is the <a>video</a>
+            element [[!HTML]].
           </p>
           <p>
             If a <a>MediaStreamTrack</a> whose <code>videoKind</code> is

--- a/index.src.html
+++ b/index.src.html
@@ -740,8 +740,8 @@
           </p>
           <p>
             The <a>MediaStream</a> <a>consumer</a> for the <a>depth-only
-            stream</a> and <a>depth+color stream</a> is <a href=
-            "#the-video-element">the <code>video</code> element</a> [[!HTML]].
+            stream</a> and <a>depth+color stream</a> is the <a>video</a>
+            element [[!HTML]].
           </p>
           <p>
             If a <a>MediaStreamTrack</a> whose <code>videoKind</code> is


### PR DESCRIPTION
Fix ReSpec warning: "Broken local reference found in document"

PTAL @astojilj


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-depth/pull/166.html" title="Last updated on Sep 11, 2018, 8:24 AM GMT (556d26c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-depth/166/f7746e0...556d26c.html" title="Last updated on Sep 11, 2018, 8:24 AM GMT (556d26c)">Diff</a>