### PR TITLE
Remove depth map calibration parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,128 +117,12 @@
 /* workaround to hide redundant dfns */
     p.related { visibility: hidden; height: 0px; }
     </style>
-  <style id="MathJax_CHTML_styles">.mjx-chtml {display: inline-block; line-height: 0; text-indent: 0; text-align: left; text-transform: none; font-style: normal; font-weight: normal; font-size: 100%; font-size-adjust: none; letter-spacing: normal; word-wrap: normal; word-spacing: normal; white-space: nowrap; float: none; direction: ltr; max-width: none; max-height: none; min-width: 0; min-height: 0; border: 0; margin: 0; padding: 1px 0}
-.MJXc-display {display: block; text-align: center; margin: 1em 0; padding: 0}
-.mjx-chtml[tabindex]:focus, body :focus .mjx-chtml[tabindex] {display: inline-table}
-.mjx-full-width {text-align: center; display: table-cell!important; width: 10000em}
-.mjx-math {display: inline-block; border-collapse: separate; border-spacing: 0}
-.mjx-math * {display: inline-block; -webkit-box-sizing: content-box!important; -moz-box-sizing: content-box!important; box-sizing: content-box!important; text-align: left}
-.mjx-numerator {display: block; text-align: center}
-.mjx-denominator {display: block; text-align: center}
-.MJXc-stacked {height: 0; position: relative}
-.MJXc-stacked > * {position: absolute}
-.MJXc-bevelled > * {display: inline-block}
-.mjx-stack {display: inline-block}
-.mjx-op {display: block}
-.mjx-under {display: table-cell}
-.mjx-over {display: block}
-.mjx-over > * {padding-left: 0px!important; padding-right: 0px!important}
-.mjx-under > * {padding-left: 0px!important; padding-right: 0px!important}
-.mjx-stack > .mjx-sup {display: block}
-.mjx-stack > .mjx-sub {display: block}
-.mjx-prestack > .mjx-presup {display: block}
-.mjx-prestack > .mjx-presub {display: block}
-.mjx-delim-h > .mjx-char {display: inline-block}
-.mjx-surd {vertical-align: top}
-.mjx-mphantom * {visibility: hidden}
-.mjx-merror {background-color: #FFFF88; color: #CC0000; border: 1px solid #CC0000; padding: 2px 3px; font-style: normal; font-size: 90%}
-.mjx-annotation-xml {line-height: normal}
-.mjx-mtr {display: table-row}
-.mjx-mlabeledtr {display: table-row}
-.mjx-mtd {display: table-cell; text-align: center}
-.mjx-label {display: table-row}
-.mjx-box {display: inline-block}
-.mjx-block {display: block}
-.mjx-span {display: inline}
-.mjx-char {display: block; white-space: pre}
-.mjx-itable {display: inline-table; width: auto}
-.mjx-row {display: table-row}
-.mjx-cell {display: table-cell}
-.mjx-table {display: table; width: 100%}
-.mjx-line {display: block; height: 0}
-.mjx-strut {width: 0; padding-top: 1em}
-.mjx-vsize {width: 0}
-.MJXc-space1 {margin-left: .167em}
-.MJXc-space2 {margin-left: .222em}
-.MJXc-space3 {margin-left: .278em}
-.mjx-ex-box-test {position: absolute; width: 1px; height: 60ex}
-.mjx-line-box-test {display: table!important}
-.mjx-line-box-test span {display: table-cell!important; width: 10000em!important; min-width: 0; max-width: none; padding: 0; border: 0; margin: 0}
-.MJXc-TeX-unknown-R {font-family: monospace; font-style: normal; font-weight: normal}
-.MJXc-TeX-unknown-I {font-family: monospace; font-style: italic; font-weight: normal}
-.MJXc-TeX-unknown-B {font-family: monospace; font-style: normal; font-weight: bold}
-.MJXc-TeX-unknown-BI {font-family: monospace; font-style: italic; font-weight: bold}
-.MJXc-TeX-ams-R {font-family: MJXc-TeX-ams-R,MJXc-TeX-ams-Rw}
-.MJXc-TeX-cal-B {font-family: MJXc-TeX-cal-B,MJXc-TeX-cal-Bx,MJXc-TeX-cal-Bw}
-.MJXc-TeX-frak-R {font-family: MJXc-TeX-frak-R,MJXc-TeX-frak-Rw}
-.MJXc-TeX-frak-B {font-family: MJXc-TeX-frak-B,MJXc-TeX-frak-Bx,MJXc-TeX-frak-Bw}
-.MJXc-TeX-math-BI {font-family: MJXc-TeX-math-BI,MJXc-TeX-math-BIx,MJXc-TeX-math-BIw}
-.MJXc-TeX-sans-R {font-family: MJXc-TeX-sans-R,MJXc-TeX-sans-Rw}
-.MJXc-TeX-sans-B {font-family: MJXc-TeX-sans-B,MJXc-TeX-sans-Bx,MJXc-TeX-sans-Bw}
-.MJXc-TeX-sans-I {font-family: MJXc-TeX-sans-I,MJXc-TeX-sans-Ix,MJXc-TeX-sans-Iw}
-.MJXc-TeX-script-R {font-family: MJXc-TeX-script-R,MJXc-TeX-script-Rw}
-.MJXc-TeX-type-R {font-family: MJXc-TeX-type-R,MJXc-TeX-type-Rw}
-.MJXc-TeX-cal-R {font-family: MJXc-TeX-cal-R,MJXc-TeX-cal-Rw}
-.MJXc-TeX-main-B {font-family: MJXc-TeX-main-B,MJXc-TeX-main-Bx,MJXc-TeX-main-Bw}
-.MJXc-TeX-main-I {font-family: MJXc-TeX-main-I,MJXc-TeX-main-Ix,MJXc-TeX-main-Iw}
-.MJXc-TeX-main-R {font-family: MJXc-TeX-main-R,MJXc-TeX-main-Rw}
-.MJXc-TeX-math-I {font-family: MJXc-TeX-math-I,MJXc-TeX-math-Ix,MJXc-TeX-math-Iw}
-.MJXc-TeX-size1-R {font-family: MJXc-TeX-size1-R,MJXc-TeX-size1-Rw}
-.MJXc-TeX-size2-R {font-family: MJXc-TeX-size2-R,MJXc-TeX-size2-Rw}
-.MJXc-TeX-size3-R {font-family: MJXc-TeX-size3-R,MJXc-TeX-size3-Rw}
-.MJXc-TeX-size4-R {font-family: MJXc-TeX-size4-R,MJXc-TeX-size4-Rw}
-@font-face {font-family: MJXc-TeX-ams-R; src: local('MathJax_AMS'), local('MathJax_AMS-Regular')}
-@font-face {font-family: MJXc-TeX-ams-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_AMS-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_AMS-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_AMS-Regular.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-cal-B; src: local('MathJax_Caligraphic Bold'), local('MathJax_Caligraphic-Bold')}
-@font-face {font-family: MJXc-TeX-cal-Bx; src: local('MathJax_Caligraphic'); font-weight: bold}
-@font-face {font-family: MJXc-TeX-cal-Bw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Caligraphic-Bold.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Caligraphic-Bold.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Caligraphic-Bold.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-frak-R; src: local('MathJax_Fraktur'), local('MathJax_Fraktur-Regular')}
-@font-face {font-family: MJXc-TeX-frak-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Fraktur-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Fraktur-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Fraktur-Regular.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-frak-B; src: local('MathJax_Fraktur Bold'), local('MathJax_Fraktur-Bold')}
-@font-face {font-family: MJXc-TeX-frak-Bx; src: local('MathJax_Fraktur'); font-weight: bold}
-@font-face {font-family: MJXc-TeX-frak-Bw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Fraktur-Bold.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Fraktur-Bold.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Fraktur-Bold.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-math-BI; src: local('MathJax_Math BoldItalic'), local('MathJax_Math-BoldItalic')}
-@font-face {font-family: MJXc-TeX-math-BIx; src: local('MathJax_Math'); font-weight: bold; font-style: italic}
-@font-face {font-family: MJXc-TeX-math-BIw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Math-BoldItalic.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Math-BoldItalic.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Math-BoldItalic.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-sans-R; src: local('MathJax_SansSerif'), local('MathJax_SansSerif-Regular')}
-@font-face {font-family: MJXc-TeX-sans-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_SansSerif-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_SansSerif-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_SansSerif-Regular.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-sans-B; src: local('MathJax_SansSerif Bold'), local('MathJax_SansSerif-Bold')}
-@font-face {font-family: MJXc-TeX-sans-Bx; src: local('MathJax_SansSerif'); font-weight: bold}
-@font-face {font-family: MJXc-TeX-sans-Bw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_SansSerif-Bold.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_SansSerif-Bold.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_SansSerif-Bold.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-sans-I; src: local('MathJax_SansSerif Italic'), local('MathJax_SansSerif-Italic')}
-@font-face {font-family: MJXc-TeX-sans-Ix; src: local('MathJax_SansSerif'); font-style: italic}
-@font-face {font-family: MJXc-TeX-sans-Iw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_SansSerif-Italic.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_SansSerif-Italic.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_SansSerif-Italic.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-script-R; src: local('MathJax_Script'), local('MathJax_Script-Regular')}
-@font-face {font-family: MJXc-TeX-script-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Script-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Script-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Script-Regular.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-type-R; src: local('MathJax_Typewriter'), local('MathJax_Typewriter-Regular')}
-@font-face {font-family: MJXc-TeX-type-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Typewriter-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Typewriter-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Typewriter-Regular.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-cal-R; src: local('MathJax_Caligraphic'), local('MathJax_Caligraphic-Regular')}
-@font-face {font-family: MJXc-TeX-cal-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Caligraphic-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Caligraphic-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Caligraphic-Regular.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-main-B; src: local('MathJax_Main Bold'), local('MathJax_Main-Bold')}
-@font-face {font-family: MJXc-TeX-main-Bx; src: local('MathJax_Main'); font-weight: bold}
-@font-face {font-family: MJXc-TeX-main-Bw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Main-Bold.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Main-Bold.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Main-Bold.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-main-I; src: local('MathJax_Main Italic'), local('MathJax_Main-Italic')}
-@font-face {font-family: MJXc-TeX-main-Ix; src: local('MathJax_Main'); font-style: italic}
-@font-face {font-family: MJXc-TeX-main-Iw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Main-Italic.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Main-Italic.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Main-Italic.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-main-R; src: local('MathJax_Main'), local('MathJax_Main-Regular')}
-@font-face {font-family: MJXc-TeX-main-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Main-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Main-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Main-Regular.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-math-I; src: local('MathJax_Math Italic'), local('MathJax_Math-Italic')}
-@font-face {font-family: MJXc-TeX-math-Ix; src: local('MathJax_Math'); font-style: italic}
-@font-face {font-family: MJXc-TeX-math-Iw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Math-Italic.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Math-Italic.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Math-Italic.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-size1-R; src: local('MathJax_Size1'), local('MathJax_Size1-Regular')}
-@font-face {font-family: MJXc-TeX-size1-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Size1-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Size1-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Size1-Regular.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-size2-R; src: local('MathJax_Size2'), local('MathJax_Size2-Regular')}
-@font-face {font-family: MJXc-TeX-size2-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Size2-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Size2-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Size2-Regular.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-size3-R; src: local('MathJax_Size3'), local('MathJax_Size3-Regular')}
-@font-face {font-family: MJXc-TeX-size3-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Size3-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Size3-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Size3-Regular.otf') format('opentype')}
-@font-face {font-family: MJXc-TeX-size4-R; src: local('MathJax_Size4'), local('MathJax_Size4-Regular')}
-@font-face {font-family: MJXc-TeX-size4-Rw; src /*1*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/eot/MathJax_Size4-Regular.eot'); src /*2*/: url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/woff/MathJax_Size4-Regular.woff') format('woff'), url('https://cdn.mathjax.org/mathjax/latest/fonts/HTML-CSS/TeX/otf/MathJax_Size4-Regular.otf') format('opentype')}
-</style></head>
+  <style id="MathJax_CHTML_styles">undefined</style></head>
   <body>
     <section id="abstract">
       <p>
         This specification <a href="https://w3c.github.io/mediacapture-main/#extensibility">extends</a>
-        the <em>Media Capture and Streams</em> specification [[!GETUSERMEDIA]]
+        the <em>Media Capture and Streams</em> specification [[GETUSERMEDIA]]
         to allow a <a>depth-only stream</a> or combined <a>depth+color
         stream</a> to be requested from the web platform using APIs familiar to
         web authors.
@@ -249,7 +133,7 @@
         This extensions specification defines a new media type and
         constrainable property per <a href="https://w3c.github.io/mediacapture-main/#extensibility">Extensibility</a>
         guidelines of the <em>Media Capture and Streams</em> specification
-        [[!GETUSERMEDIA]]. Horizontal reviews and feedback from early
+        [[GETUSERMEDIA]]. Horizontal reviews and feedback from early
         implementations of this specification are encouraged.
       </p>
     </section>
@@ -325,11 +209,8 @@
         of constrainable properties</dfn> are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The <dfn data-cite="!GETUSERMEDIA#idl-def-ConstrainDOMString"><code>ConstrainDOMString</code></dfn>,
-        <dfn data-cite="!GETUSERMEDIA#idl-def-ConstrainDouble"><code>ConstrainDouble</code></dfn>,
-        <dfn data-cite="!GETUSERMEDIA#idl-def-ConstrainBoolean"><code>ConstrainBoolean</code></dfn>,
-        and <dfn data-cite="!GETUSERMEDIA#idl-def-DoubleRange"><code>DoubleRange</code></dfn>
-        types are defined in [[!GETUSERMEDIA]].
+        The <dfn data-cite="!GETUSERMEDIA#idl-def-ConstrainDOMString"><code>ConstrainDOMString</code></dfn>
+        type is defined in [[!GETUSERMEDIA]].
       </p>
       <p>
         <dfn data-cite="GETUSERMEDIA#idl-def-MediaTrackSettings"><code>MediaTrackSettings</code></dfn>,
@@ -448,113 +329,18 @@
         <p>
           <dfn>Normalized</dfn> <a>depth map value</a> means that it's range is
           from 0 to 1, where maximum <a>depth map value</a> of 1 corresponds to
-          distances equal to <a>far value</a>. Following the <a href="#dfn-calculate-depth-map-value">conversion between depth map value
-          and distance</a>, the minumum value of 0 would correspond to
-          distances equal to <a>near value</a>, but 0 has a special meaning -
-          it is an <dfn>invalid depth map value</dfn> and represents that the
-          user agent is unable to acquire depth information for the given pixel
-          for any reason. <a>Normalized</a> <a>depth map value</a> is
-          represented using <dfn>floating-point</dfn> or <dfn>unsigned
-          fixed-point</dfn> formats <a href="https://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.5.pdf#subsection.2.1.6">
+          distances equal to <a>far plane</a>. <a>Normalized</a> <a>depth map
+          value</a> is represented using <dfn>floating-point</dfn> or
+          <dfn>unsigned fixed-point</dfn> formats <a href="https://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.5.pdf#subsection.2.1.6">
           [OpenGL ES 3.0.5]#subsection.2.1.6</a>.
         </p>
         <p>
-          A <a>depth map</a> has an associated <dfn>near value</dfn> which is a
-          double. It represents the minimum range in meters and it defines
-          <dfn>near plane</dfn> which is a plane perpendicular to camera
-          viewing direction on distance <a>near value</a> from the camera
-          origin.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>far value</dfn> which is a
-          double. It represents the maximum range in meters. It represents the
-          minimum range in meters and it defines <dfn>far plane</dfn> which is
-          a plane perpendicular to camera viewing direction on distance <a>far
-          value</a> from the camera origin.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>horizontal focal
-          length</dfn> which is a double. It represents the horizontal
-          <dfn>focal length</dfn> of the depth camera, in pixels.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>vertical focal length</dfn>
-          which is a double. It represents the vertical focal length of the
-          depth camera, in pixels.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>principal point</dfn>,
-          specified by <dfn>principal point x</dfn> and <dfn>principal point
-          y</dfn> coordinates which are double. It is a concept defined in the
-          pinhole camera model; a projection of perspective center to the image
-          plane.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>transformation from depth
-          to video</dfn>, which is a <dfn>transformation matrix</dfn>
-          represented by a <a>Transformation</a> dictionary. It is used to
-          translate position in depth camera 3D coordinate system to RGB video
-          stream's camera (identified by <dfn>videoDeviceId</dfn>) 3D
-          coordinate system. After projecting depth 2D pixel coordinates to 3D
-          space, we use this matrix to transform depth camera 3D space
-          coordinates to RGB video camera 3D space.
-        </p>
-        <p>
-          Both depth and color cameras usually introduce significant distortion
-          caused by the camera and lens. While in some cases, the effects are
-          not noticeable, these distortions cause errors in image analysis. To
-          map <a>depth map</a> pixel values to corresponding color video track
-          pixels, we use two <a>DistortionCoefficients</a> dictionaries:
-          <dfn>deprojection distortion coefficients</dfn> and <dfn>projection
-          distortion coefficients</dfn>.
-        </p>
-        <p>
-          <a>Deprojection distortion coefficients</a> are used for compensating
-          camera distortion when deprojecting 2D pixel coordinates to 3D space
-          coordinates. <a>Projection distortion coefficients</a> are used in
-          the opposite case, when projecting camera 3D space points to pixels.
-          One track doesn't have both of the coefficients specified. The most
-          common scenario is that the depth track has <a>deprojection
-          distortion coefficients</a> or that the color video track has
-          <a>projection distortion coefficients</a>. For the details, see
-          <a>algorithm to map depth pixels to color pixels</a>.
+          <a>Depth map</a>'s <dfn>near plane</dfn> and <dfn>far plane</dfn> are
+          concepts of 3D graphics that define camera viewing volume (view
+          frustum). Their definition is outside the scope of this
+          specification.
         </p>
       </section>
-    </section>
-    <section>
-      <h2>
-        Conversion between depth map value and distance
-      </h2>
-      <p>
-        A <a>depth map value</a> is a distance to <a>near plane</a>
-        <a>normalized</a> against the distance between <a href="#dfn-far-plane">far</a> and <a href="#dfn-near-plane">near</a> plane:
-      </p>
-      <ul>
-        <li>Let <var>near</var> be the the <a>near value</a>.
-        </li>
-        <li>Let <var>far</var> be the the <a>far value</a>.
-        </li>
-        <li>Let <var>d</var> be the the distance to <a>near plane</a>.
-        </li>
-        <li>Let <var>depth</var> be the the <a>depth map value</a>.
-        </li>
-        <li>The formula to <dfn>calculate depth map value</dfn>
-        <var>depth</var> for the given distance <var>d</var> is:
-          <p>
-            <span id="MathJax-Element-1-Frame" class="mjx-chtml"><span id="MJXc-Node-1" class="mjx-math"><span id="MJXc-Node-2" class="mjx-mrow"><span id="MJXc-Node-3" class="mjx-mstyle"><span id="MJXc-Node-4" class="mjx-mrow"><span id="MJXc-Node-5" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-6" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-7" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-8" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span><span id="MJXc-Node-9" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-10" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-11" class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style="width: 5.087em; padding: 0px 0.12em;"><span class="mjx-numerator" style="width: 5.087em; top: -1.396em;"><span id="MJXc-Node-12" class="mjx-mrow"><span id="MJXc-Node-13" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-14" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">−</span></span><span id="MJXc-Node-15" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-16" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-17" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-18" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span></span></span><span class="mjx-denominator" style="width: 5.087em; bottom: -1em;"><span id="MJXc-Node-19" class="mjx-mrow"><span id="MJXc-Node-20" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-21" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-22" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-23" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">−</span></span><span id="MJXc-Node-24" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-25" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-26" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-27" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 5.087em;" class="mjx-line"></span></span><span style="height: 2.396em; vertical-align: -1em;" class="mjx-vsize"></span></span></span></span></span></span></span>
-          </p>
-        </li>
-        <li>If the distance <var>d</var> is greater than <a>far value</a>, the
-        depth is <a>invalid depth map value</a>.
-        </li>
-        <li>The formula to <dfn>convert the depth map value to distance</dfn>
-        <var>d</var>, for a <a>depth map value</a> <var>depth</var>, is as
-        follows:
-          <p>
-            <span id="MathJax-Element-2-Frame" class="mjx-chtml"><span id="MJXc-Node-28" class="mjx-math"><span id="MJXc-Node-29" class="mjx-mrow"><span id="MJXc-Node-30" class="mjx-mstyle"><span id="MJXc-Node-31" class="mjx-mrow"><span id="MJXc-Node-32" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-33" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-34" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-35" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-36" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-37" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.372em; padding-bottom: 0.298em;">t</span></span><span id="MJXc-Node-38" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em;">h</span></span><span id="MJXc-Node-39" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-40" class="mjx-mrow"><span id="MJXc-Node-41" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.446em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-42" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-43" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-44" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-45" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">−</span></span><span id="MJXc-Node-46" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-47" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-48" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-49" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-50" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.446em; padding-bottom: 0.593em;">)</span></span></span><span id="MJXc-Node-51" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-52" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">n</span></span><span id="MJXc-Node-53" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">e</span></span><span id="MJXc-Node-54" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">a</span></span><span id="MJXc-Node-55" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span></span></span></span></span></span>
-          </p>
-        </li>
-      </ul>
     </section>
     <section>
       <h2>
@@ -585,18 +371,8 @@
           agent</a> in step 6.2.2 in the <a>getUserMedia()</a> algorithm.
         </p>
         <pre class="idl">          partial dictionary MediaTrackSupportedConstraints {
-              // Apply to both depth stream track and color stream track:
+              // Applies to both depth stream track and color stream track:
               boolean videoKind = true;
-              boolean focalLengthX = false;
-              boolean focalLengthY = false;
-              boolean principalPointX = false;
-              boolean principalPointY = false;
-              boolean deprojectionDistortionCoefficients = false;
-              boolean projectionDistortionCoefficients = false;
-              // Apply to depth stream track:
-              boolean depthNear = false;
-              boolean depthFar = false;
-              boolean depthToVideoTransform = false;
           };
       
 </pre>
@@ -615,18 +391,8 @@
           [[!GETUSERMEDIA]].
         </p>
         <pre class="idl">          partial dictionary MediaTrackCapabilities {
-              // Apply to both depth stream track and color stream track:
+              // Applies to both depth stream track and color stream track:
               DOMString videoKind;
-              (double or DoubleRange) focalLengthX;
-              (double or DoubleRange) focalLengthY;
-              (double or DoubleRange) principalPointX;
-              (double or DoubleRange) principalPointY;
-              boolean deprojectionDistortionCoefficients;
-              boolean projectionDistortionCoefficients;
-              // Apply to depth stream track:
-              (double or DoubleRange) depthNear;
-              (double or DoubleRange) depthFar;
-              boolean depthToVideoTransform;
           };
 </pre>
       </section>
@@ -639,23 +405,12 @@
           <a>allowed values</a>.
         </p>
         <p>
-          The <dfn>allowed values</dfn> for <a>ConstrainDOMString</a>,
-          <a>ConstrainDouble</a>, and <a>ConstrainBoolean</a> types are defined
-          in [[!GETUSERMEDIA]] respectively.
+          The <dfn>allowed values</dfn> for <a>ConstrainDOMString</a> type are
+          defined in [[!GETUSERMEDIA]].
         </p>
         <pre class="idl">          partial dictionary MediaTrackConstraintSet {
-              // Apply to both depth stream track and color stream track:
+              // Applies to both depth stream track and color stream track:
               ConstrainDOMString videoKind;
-              ConstrainDouble focalLengthX;
-              ConstrainDouble focalLengthY;
-              ConstrainDouble principalPointX;
-              ConstrainDouble principalPointY;
-              ConstrainBoolean deprojectionDistortionCoefficients;
-              ConstrainBoolean projectionDistortionCoefficients;
-              // Apply to depth stream track:
-              ConstrainDouble depthNear;
-              ConstrainDouble depthFar;
-              ConstrainBoolean depthToVideoTransform;
           };
 </pre>
       </section>
@@ -672,120 +427,32 @@
           <a>MediaTrackSettings</a> dictionary.
         </p>
         <pre class="idl">          partial dictionary MediaTrackSettings {
-              // Apply to both depth stream track and color stream track:
+              // Applies to both depth stream track and color stream track:
               DOMString           videoKind;
-              double              focalLengthX;
-              double              focalLengthY;
-              double              principalPointX;
-              double              principalPointY;
-              DistortionCoefficients deprojectionDistortionCoefficients;
-              DistortionCoefficients projectionDistortionCoefficients;
-              // Apply to depth stream track:
-              double              depthNear;
-              double              depthFar;
-              Transformation      depthToVideoTransform;
           };
         
 </pre>
-        <section>
-          <h2>
-            <code>DistortionCoefficients</code> dictionary
-          </h2>
-          <pre class="idl">          dictionary DistortionCoefficients {
-              double              k1;
-              double              k2;
-              double              p1;
-              double              p2;
-              double              k3;
-          };
-        
-</pre>
-          <div data-dfn-for="DistortionCoefficients">
-            <p>
-              The <dfn><code>DistortionCoefficients</code></dfn> dictionary has
-              the <dfn>k1</dfn>, <dfn>k2</dfn>, <dfn>p1</dfn>, <dfn>p2</dfn>
-              and <dfn>k3</dfn> dictionary members that represent the
-              <a>deprojection distortion coefficients</a> or <a>projection
-              distortion coefficients</a>. <dfn data-dfn-for="k1">k1</dfn>,
-              <dfn data-dfn-for="k2">k2</dfn> and <dfn data-dfn-for="k3">k3</dfn> are <dfn>radial distortion coefficients</dfn> while
-              <dfn data-dfn-for="p1">p1</dfn> and <dfn data-dfn-for="p2">p2</dfn> are <dfn>tangential distortion coefficients</dfn>.
-              <a>Radial distortion coefficients</a> and <a>tangential
-              distortion coefficients</a> are used to <a>deproject</a> depth
-              value to 3D space or to <a>project</a> 3D value to 2D video frame
-              coordinates.
-            </p>
-            <p class="note">
-              See the <a>algorithm to map depth pixels to color pixels</a> and
-              Brown-Conrady distortion model implementation in <a>3D point
-              cloud rendering</a> example GLSL shader.<br>
-            </p>
-          </div>
-        </section>
-        <section>
-          <h2>
-            <code>Transformation</code> dictionary
-          </h2>
-          <pre class="idl">          dictionary Transformation {
-            Float32Array       transformationMatrix;
-            DOMString          videoDeviceId;
-          };
-        
-</pre>
-          <div data-dfn-for="Transformation">
-            <p>
-              The <dfn><code>Transformation</code></dfn> dictionary has the
-              <dfn><code>transformationMatrix</code></dfn> dictionary member
-              that is a 16 element array that defines the <a>transformation
-              matrix</a> of the <a>depth map</a>'s camera's 3D coordinate
-              system to video track's camera 3D coordinate system.
-            </p>
-            <p>
-              The first four elements of the array correspond to the first
-              matrix row, followed by four elements of the second matrix row
-              and so on. It is in format suitable for use with WebGL's
-              uniformMatrix4fv.
-            </p>
-            <p>
-              The <dfn><code>videoDeviceId</code></dfn> dictionary member
-              represents the <code>deviceId</code> of video camera the depth
-              stream must be synchronized with.
-            </p>
-            <p class="note">
-              The value of <a><code>videoDeviceId</code></a> can be used as the
-              <code>deviceId</code> constraint in [[!GETUSERMEDIA]] to get the
-              corresponding video and audio streams.
-            </p>
-          </div>
-        </section>
-      </section>
-      <section>
-        <h2>
-          Constrainable properties for color stream track and depth stream
-          track
-        </h2>
-        <p>
-          The following constrainable properties are defined to apply to both
-          <a>color stream track</a> and <a>depth stream track</a>.
-        </p>
         <section id="def-constraint-videoKind">
-          <h3>
-            <code>videoKind</code>
-          </h3>
+          <h2>
+            Video kind constrainable property
+          </h2>
+          <p>
+            The <code>videoKind</code> constrainable property is defined to
+            apply to both <a>color stream track</a> and <a>depth stream
+            track</a>. The <code>videoKind</code> member specifies the
+            <dfn>video kind</dfn> of the <a>source</a>.
+          </p>
           <p class="related">
             Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for="MediaTrackSupportedConstraints">videoKind</dfn>,
             <a>MediaTrackCapabilities</a>.<dfn data-dfn-for="MediaTrackCapabilities">videoKind</dfn>,
             <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for="MediaTrackConstraintSet">videoKind</dfn>,
             <a>MediaTrackSettings</a>.<dfn data-dfn-for="MediaTrackSettings">videoKind</dfn>
           </p>
-          <p>
-            The <code>videoKind</code> member specifies the <dfn>video
-            kind</dfn> of the <a>source</a>.
-          </p>
-          <pre class="idl">          enum VideoKindEnum {
-              "color",
-              "depth"
-          };
-          
+          <pre class="idl">        enum VideoKindEnum {
+            "color",
+            "depth"
+        };
+        
 </pre>
           <p>
             The <dfn>VideoKindEnum</dfn> enumeration defines the valid <a>video
@@ -805,497 +472,87 @@
             <a>disabled</a>, it MUST render frames as if all the pixels would
             be 0.
           </p>
+        </section>
+        <section class="informative">
+          <h2>
+            WebGL implementation considerations
+          </h2>
           <div class="note">
-            <p>
-              A <a>color stream track</a> and a <a>depth stream track</a> can
-              be combined into one <a>depth+color stream</a>. The rendering of
-              the two tracks are intended to be synchronized. The resolution of
-              the two tracks are intended to be same. And the coordination of
-              the two tracks are intended to be calibrated. These are not hard
-              requirements, since it might not be possible to synchronize
-              tracks from sources.
-            </p>
-            <p>
-              This approach is simple to use but comes with the following
-              caveats: it might might not be supported by the implementation
-              and the resolutions of two tracks are intended to be the same
-              that can require downsampling and degrade quality. The
-              alternative approach is that a web developer implements the
-              <a>algorithm to map depth pixels to color pixels</a>. See the
-              <a>3D point cloud rendering</a> example code.
-            </p>
+            This section is currently work in progress, and subject to change.
           </div>
-        </section>
-        <section id="def-constraint-focalLengthX">
-          <h3>
-            <code>focalLengthX</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for="MediaTrackSupportedConstraints">focalLengthX</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for="MediaTrackCapabilities">focalLengthX</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for="MediaTrackConstraintSet">focalLengthX</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for="MediaTrackSettings">focalLengthX</dfn>
+          <p>
+            <a>Depth map</a> values that the camera produces are often in
+            16-bit <a>normalized</a> <a>unsigned fixed-point</a> format.
+            Application developer can access the data using <a>canvas pixel
+            arraybuffer</a> red color component, but that would cause a
+            precision loss given that it is in 8-bit <a>normalized</a>
+            <a>unsigned fixed-point</a> format.
           </p>
           <p>
-            The <code>focalLengthX</code> member specifies the <a>horizontal
-            focal length</a>, in pixels.
-          </p>
-        </section>
-        <section id="def-constraint-focalLengthY">
-          <h3>
-            <code>focalLengthY</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for="MediaTrackSupportedConstraints">focalLengthY</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for="MediaTrackCapabilities">focalLengthY</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for="MediaTrackConstraintSet">focalLengthY</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for="MediaTrackSettings">focalLengthY</dfn>
+            The same precision loss is related to usage of [[WEBGL]]
+            <code>UNSIGNED_BYTE</code> textures. In order to access the full
+            precision, application developer <a href="#dfn-uploaded">can
+            use</a> [[WEBGL]] <a>floating-point</a> textures.
           </p>
           <p>
-            The <code>focalLengthY</code> member specifies the <a>vertical
-            focal length</a>, in pixels.
-          </p>
-        </section>
-        <section id="def-constraint-principalPointX">
-          <h3>
-            <code>principalPointX</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for="MediaTrackSupportedConstraints">principalPointX</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for="MediaTrackCapabilities">principalPointX</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for="MediaTrackConstraintSet">principalPointX</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for="MediaTrackSettings">principalPointX</dfn>
+            There are several use-cases which are a good fit to be, at least
+            partially, implemented on the GPU, such as motion recognition,
+            pattern recognition, background removal, as well as 3D point cloud.
           </p>
           <p>
-            The <code>principalPointX</code> member specifies the <a>principal
-            point x</a> coordinate, in pixels.
+            This section explains which APIs can be used for some of these
+            mentioned use-cases; the concrete examples are provided in the
+            <a href="#examples">Examples</a> section.
           </p>
-        </section>
-        <section id="def-constraint-principalPointY">
-          <h3>
-            <code>principalPointY</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for="MediaTrackSupportedConstraints">principalPointY</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for="MediaTrackCapabilities">principalPointY</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for="MediaTrackConstraintSet">principalPointY</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for="MediaTrackSettings">principalPointY</dfn>
-          </p>
-          <p>
-            The <code>principalPointY</code> member specifies the <a>principal
-            point y</a> coordinate, in pixels.
-          </p>
-        </section>
-        <section id="def-constraint-deprojectionDistortionCoefficients">
-          <h3>
-            <code>deprojectionDistortionCoefficients</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for="MediaTrackSupportedConstraints">deprojectionDistortionCoefficients</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for="MediaTrackCapabilities">deprojectionDistortionCoefficients</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for="MediaTrackConstraintSet">deprojectionDistortionCoefficients</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for="MediaTrackSettings">deprojectionDistortionCoefficients</dfn>
-          </p>
-          <p>
-            The <code>deprojectionDistortionCoefficients</code> member
-            specifies the <a>MediaStreamTrack</a>'s <a>deprojection distortion
-            coefficients</a> used when deprojecting from 2D to 3D space.
-          </p>
-        </section>
-        <section id="def-constraint-projectionDistortionCoefficients">
-          <h3>
-            <code>projectionDistortionCoefficients</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for="MediaTrackSupportedConstraints">projectionDistortionCoefficients</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for="MediaTrackCapabilities">projectionDistortionCoefficients</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for="MediaTrackConstraintSet">projectionDistortionCoefficients</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for="MediaTrackSettings">projectionDistortionCoefficients</dfn>
-          </p>
-          <p>
-            The <code>projectionDistortionCoefficients</code> member specifies
-            the <a>MediaStreamTrack</a>'s <a>projection distortion
-            coefficients</a> used when deprojecting from 2D to 3D space.
-          </p>
-        </section>
-      </section>
-      <section>
-        <h2>
-          Constrainable properties for depth stream track
-        </h2>
-        <p>
-          The following constrainable properties are defined to apply only to
-          <a>depth stream track</a>.
-        </p>
-        <section id="def-constraint-depthNear-depthFar">
-          <h3>
-            <code>depthNear</code> and <code>depthFar</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for="MediaTrackSupportedConstraints">depthNear</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for="MediaTrackCapabilities">depthNear</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for="MediaTrackConstraintSet">depthNear</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for="MediaTrackSettings">depthNear</dfn>,
-            <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for="MediaTrackSupportedConstraints">depthFar</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for="MediaTrackCapabilities">depthFar</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for="MediaTrackConstraintSet">depthFar</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for="MediaTrackSettings">depthFar</dfn>
-          </p>
-          <p>
-            The <code>depthNear</code> member specifies the <a>near value</a>,
-            in meters.
-          </p>
-          <p>
-            The <code>depthFar</code> member specifies the <a>far value</a>, in
-            meters.
-          </p>
-          <p>
-            The <code>depthNear</code> and <code>depthFar</code> constrainable
-            properties, when set, allow the implementation to pick the best
-            depth camera mode optimized for the range <code>[depthNear,
-            depthFar]</code> and help minimize the error introduced by the
-            lossy conversion from the depth value <var>d</var> to a quantized
-            d<sub>8bit</sub> and back to an approximation of the depth value
-            <var>d</var>.
-          </p>
-          <p>
-            If the <code>depthFar</code> property's value is less than the
-            <code>depthNear</code> property's value, the <a>depth stream
-            track</a> is <a>overconstrained</a>.
-          </p>
-        </section>
-        <section id="def-constraint-depthToVideoTransform">
-          <h3>
-            <code>depthToVideoTransform</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for="MediaTrackSupportedConstraints">depthToVideoTransform</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for="MediaTrackCapabilities">depthToVideoTransform</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for="MediaTrackConstraintSet">depthToVideoTransform</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for="MediaTrackSettings">depthToVideoTransform</dfn>
-          </p>
-          <p>
-            The <code>depthToVideoTransform</code> member specifies the
-            <a>depth map</a>'s camera's <a>transformation from depth to
-            video</a> camera 3D coordinate system.
-          </p>
+          <section>
+            <h3>
+              Upload video frame to WebGL texture
+            </h3>
+            <p>
+              A <a>video</a> element whose source is a <a>MediaStream</a>
+              object containing a <a>depth stream track</a> may be
+              <dfn>uploaded</dfn> to a [[WEBGL]] texture of format
+              <code>RGBA</code> or <code>RED</code> and type
+              <code>FLOAT</code>. See the specification [[WEBGL]] and the
+              <a>upload to float texture</a> example code.
+            </p>
+            <p>
+              For each pixel of this WebGL texture, the R component represents
+              <a>normalized</a> <a>floating-point</a> <a>depth map value</a>.
+            </p>
+          </section>
+          <section>
+            <h3>
+              Read the data from a WebGL texture
+            </h3>
+            <p>
+              Here we list some of the possible approaches.
+            </p>
+            <ul>
+              <li>Synchronous readPixels usage requires the least amount of
+              code and it is available with WebGL 1.0. See the <a>readPixels
+              from float</a> example for further details.
+              </li>
+              <li>Asynchronous readPixels using pixel buffer objects to avoid
+              blocking the readPixels call.
+              </li>
+              <li>Transform feedback [[WEBGL2]] with GetBufferSubData(Async)
+              [[WEBGL-GET-BUFFER-SUB-DATA-ASYNC]] provides synchronous and
+              asynchronous read access to depth and color texture data
+              processed in the vertex shader.
+              </li>
+            </ul>
+          </section>
         </section>
       </section>
       <section class="informative">
         <h2>
-          WebGL implementation considerations
+          Examples
         </h2>
-        <div class="note">
-          This section is currently work in progress, and subject to change.
-        </div>
-        <p>
-          <a>Depth map</a> values that the camera produces are often in 16-bit
-          <a>normalized</a> <a>unsigned fixed-point</a> format. Application
-          developer can access the data using <a>canvas pixel arraybuffer</a>
-          red color component, but that would cause a precision loss given that
-          it is in 8-bit <a>normalized</a> <a>unsigned fixed-point</a> format.
-        </p>
-        <p>
-          The same precision loss is related to usage of [[WEBGL]]
-          <code>UNSIGNED_BYTE</code> textures. In order to access the full
-          precision, application developer <a href="#dfn-uploaded">can use</a>
-          [[WEBGL]] <a>floating-point</a> textures.
-        </p>
-        <p>
-          There are several use-cases which are a good fit to be, at least
-          partially, implemented on the GPU, such as motion recognition,
-          pattern recognition, background removal, as well as 3D point cloud.
-        </p>
-        <p>
-          This section explains which APIs can be used for some of these
-          mentioned use-cases; the concrete examples are provided in the
-          <a href="#examples">Examples</a> section.
-        </p>
-        <section>
-          <h3>
-            Upload video frame to WebGL texture
-          </h3>
-          <p>
-            A <a>video</a> element whose source is a <a>MediaStream</a> object
-            containing a <a>depth stream track</a> may be <dfn>uploaded</dfn>
-            to a [[WEBGL]] texture of format <code>RGBA</code> or
-            <code>RED</code> and type <code>FLOAT</code>. See the specification
-            [[WEBGL]] and the <a>upload to float texture</a> example code.
-          </p>
-          <p>
-            For each pixel of this WebGL texture, the R component represents
-            <a>normalized</a> <a>floating-point</a> <a>depth map value</a>.
-          </p>
-        </section>
-        <section>
-          <h3>
-            Read the data from a WebGL texture
-          </h3>
-          <p>
-            Here we list some of the possible approaches.
-          </p>
-          <ul>
-            <li>Synchronous readPixels usage requires the least amount of code
-            and it is available with WebGL 1.0. See the <a>readPixels from
-            float</a> example for further details.
-            </li>
-            <li>Asynchronous readPixels using pixel buffer objects to avoid
-            blocking the readPixels call.
-            </li>
-            <li>Transform feedback [[WEBGL2]] with GetBufferSubData(Async)
-            [[WEBGL-GET-BUFFER-SUB-DATA-ASYNC]] provides synchronous and
-            asynchronous read access to depth and color texture data processed
-            in the vertex shader.
-            </li>
-          </ul>
-        </section>
-      </section>
-    </section>
-    <section class="informative">
-      <h2>
-        Synchronizing depth and color video rendering
-      </h2>
-      <p class="note">
-        The algorithms presented in this section explain how a web developer
-        can <dfn>map depth and color</dfn> pixels. Concrete example on how to
-        do the mapping is provided in example vertex shader used for <a>3D
-        point cloud rendering</a>.
-      </p>
-      <p></p>
-      <p>
-        When rendering, we want to position a color value from color video
-        frame to corresponding <a>depth map value</a> or 3D point in space
-        defined by <a>depth map value</a>. We use <a>deprojection distortion
-        coefficients</a> to compensate camera distortion when deprojecting 2D
-        pixel coordinates to 3D space coordinates and <a>projection distortion
-        coefficients</a> in the opposite case, when projecting camera 3D space
-        points to pixels.
-      </p>
-      <p>
-        The <dfn>algorithm to map depth pixels to color pixels</dfn> is as
-        follows:
-      </p>
-      <ol>
-        <li>
-          <a>Deproject</a> <a>depth map value</a> to point in depth 3D space.
-        </li>
-        <li>
-          <a>Transform</a> 3D point from depth camera 3D space to color camera
-          3D space.
-        </li>
-        <li>
-          <a>Project</a> from color camera 3D space to color frame 2D pixels.
-        </li>
-      </ol>
-      <p></p>
-      <section>
-        <h2>
-          Deproject to depth 3D space
-        </h2>
-        <p>
-          The algorithm to <dfn>deproject</dfn> depth map value to point in
-          depth camera is as follows:
-        </p>
-        <p>
-          Let <var>dx</var> and <var>dy</var> be 2D coordinates, in pixels, of
-          a pixel in <a>depth map</a>.
-        </p><var></var>
-        <p>
-          Let <var>dz</var> be <a>depth map value</a> of the same pixel in the
-          <a>depth map</a>.
-        </p>
-        <p>
-          Let <var>fx</var> and <var>fy</var> be <a>depth map</a>'s
-          <a>horizontal focal length</a> and <a>vertical focal length</a>
-          respectively.
-        </p>
-        <p>
-          Let <var>cx</var> and <var>cy</var> be <a>depth map</a>'s
-          <a>principal point</a> 2D coordinates.
-        </p>
-        <p>
-          Let 3D coordinates (Xd, Yd, Zd) be the output of this step - a 3D
-          point in depth camera's 3D coordinate system.
-        </p>
-        <p>
-          <span id="MathJax-Element-3-Frame" class="mjx-chtml"><span id="MJXc-Node-56" class="mjx-math"><span id="MJXc-Node-57" class="mjx-mrow"><span id="MJXc-Node-58" class="mjx-mstyle"><span id="MJXc-Node-59" class="mjx-mrow"><span id="MJXc-Node-60" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-61" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span><span id="MJXc-Node-62" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-63" class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style="width: 3.611em; padding: 0px 0.12em;"><span class="mjx-numerator" style="width: 3.611em; top: -1.396em;"><span id="MJXc-Node-64" class="mjx-mrow"><span id="MJXc-Node-65" class="mjx-mrow"><span id="MJXc-Node-66" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-67" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span id="MJXc-Node-68" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">−</span></span><span id="MJXc-Node-69" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span id="MJXc-Node-70" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span></span><span class="mjx-denominator" style="width: 3.611em; bottom: -1em;"><span id="MJXc-Node-71" class="mjx-mrow"><span id="MJXc-Node-72" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-73" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 3.611em;" class="mjx-line"></span></span><span style="height: 2.396em; vertical-align: -1em;" class="mjx-vsize"></span></span></span></span></span></span></span>
-        </p>
-        <p>
-          <span id="MathJax-Element-4-Frame" class="mjx-chtml"><span id="MJXc-Node-74" class="mjx-math"><span id="MJXc-Node-75" class="mjx-mrow"><span id="MJXc-Node-76" class="mjx-mstyle"><span id="MJXc-Node-77" class="mjx-mrow"><span id="MJXc-Node-78" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-79" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span><span id="MJXc-Node-80" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-81" class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style="width: 3.459em; padding: 0px 0.12em;"><span class="mjx-numerator" style="width: 3.459em; top: -1.489em;"><span id="MJXc-Node-82" class="mjx-mrow"><span id="MJXc-Node-83" class="mjx-mrow"><span id="MJXc-Node-84" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-85" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span id="MJXc-Node-86" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">−</span></span><span id="MJXc-Node-87" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span id="MJXc-Node-88" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span></span><span class="mjx-denominator" style="width: 3.459em; bottom: -1em;"><span id="MJXc-Node-89" class="mjx-mrow"><span id="MJXc-Node-90" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-91" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 3.459em;" class="mjx-line"></span></span><span style="height: 2.489em; vertical-align: -1em;" class="mjx-vsize"></span></span></span></span></span></span></span>
-        </p>
-        <ul>
-          <li>If <a>depth map</a>'s <a>deprojection distortion coefficients</a>
-          are <a>not present</a> in <a href="#mediatracksettings-dictionary">MediaTrackSettings</a> dictionary,
-            <p>
-              3D coordinates (Xd, Yd, Zd) in depth camera space are calculated
-              as:
-            </p>
-            <p>
-              <span id="MathJax-Element-5-Frame" class="mjx-chtml"><span id="MJXc-Node-92" class="mjx-math"><span id="MJXc-Node-93" class="mjx-mrow"><span id="MJXc-Node-94" class="mjx-mstyle"><span id="MJXc-Node-95" class="mjx-mrow"><span id="MJXc-Node-96" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;">X</span></span><span id="MJXc-Node-97" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-98" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-99" class="mjx-mrow"><span id="MJXc-Node-100" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-101" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;">z</span></span></span><span id="MJXc-Node-102" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-103" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-104" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-6-Frame" class="mjx-chtml"><span id="MJXc-Node-105" class="mjx-math"><span id="MJXc-Node-106" class="mjx-mrow"><span id="MJXc-Node-107" class="mjx-mstyle"><span id="MJXc-Node-108" class="mjx-mrow"><span id="MJXc-Node-109" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.182em;">Y</span></span><span id="MJXc-Node-110" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-111" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-112" class="mjx-mrow"><span id="MJXc-Node-113" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-114" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;">z</span></span></span><span id="MJXc-Node-115" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-116" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-117" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-7-Frame" class="mjx-chtml"><span id="MJXc-Node-118" class="mjx-math"><span id="MJXc-Node-119" class="mjx-mrow"><span id="MJXc-Node-120" class="mjx-mstyle"><span id="MJXc-Node-121" class="mjx-mrow"><span id="MJXc-Node-122" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.04em;">Z</span></span><span id="MJXc-Node-123" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-124" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-125" class="mjx-mrow"><span id="MJXc-Node-126" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-127" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;">z</span></span></span></span></span></span></span></span>
-            </p>
-          </li>
-          <li>If <a>depth map</a>'s <a>deprojection distortion coefficients</a>
-          <a>k1</a>, <a>k2</a>, <a>k3</a>, <a>p1</a> and <a>p2</a> are
-          <a>present</a> in <a href="#mediatracksettings-dictionary">MediaTrackSettings</a> dictionary,
-          with a note that some of those could be zero,
-            <p>
-              3D coordinates (Xd, Yd, Zd) in depth camera space are calculated
-              as:
-            </p>
-            <p>
-              <span id="MathJax-Element-8-Frame" class="mjx-chtml"><span id="MJXc-Node-128" class="mjx-math"><span id="MJXc-Node-129" class="mjx-mrow"><span id="MJXc-Node-130" class="mjx-mstyle"><span id="MJXc-Node-131" class="mjx-mrow"><span id="MJXc-Node-132" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-133" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-134" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-135" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-136" class="mjx-msup"><span class="mjx-base"><span id="MJXc-Node-137" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.584em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-138" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span></span><span id="MJXc-Node-139" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-140" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-141" class="mjx-msup"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-142" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.584em; padding-left: 0.082em; padding-right: 0.071em;"><span id="MJXc-Node-143" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-9-Frame" class="mjx-chtml"><span id="MJXc-Node-144" class="mjx-math"><span id="MJXc-Node-145" class="mjx-mrow"><span id="MJXc-Node-146" class="mjx-mstyle"><span id="MJXc-Node-147" class="mjx-mrow"><span id="MJXc-Node-148" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-149" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-150" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">1</span></span><span id="MJXc-Node-151" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-152" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em;">k</span></span><span id="MJXc-Node-153" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">1</span></span><span id="MJXc-Node-154" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-155" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-156" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-157" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-158" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em;">k</span></span><span id="MJXc-Node-159" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-160" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-161" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-162" class="mjx-msup"><span class="mjx-base"><span id="MJXc-Node-163" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.591em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-164" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span></span><span id="MJXc-Node-165" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-166" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em;">k</span></span><span id="MJXc-Node-167" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">3</span></span><span id="MJXc-Node-168" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-169" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-170" class="mjx-msup"><span class="mjx-base"><span id="MJXc-Node-171" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.591em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-172" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">3</span></span></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-10-Frame" class="mjx-chtml"><span id="MJXc-Node-173" class="mjx-math"><span id="MJXc-Node-174" class="mjx-mrow"><span id="MJXc-Node-175" class="mjx-mstyle"><span id="MJXc-Node-176" class="mjx-mrow"><span id="MJXc-Node-177" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;">X</span></span><span id="MJXc-Node-178" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-179" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-180" class="mjx-mrow"><span id="MJXc-Node-181" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-182" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;">z</span></span></span><span id="MJXc-Node-183" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-184" class="mjx-mrow"><span id="MJXc-Node-185" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-186" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-187" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span><span id="MJXc-Node-188" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-189" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-190" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-191" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-192" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-193" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-194" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">1</span></span><span id="MJXc-Node-195" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-196" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-197" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span><span id="MJXc-Node-198" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-199" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-200" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span><span id="MJXc-Node-201" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-202" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-203" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-204" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-205" class="mjx-mrow"><span id="MJXc-Node-206" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-207" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-208" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-209" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-210" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-211" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-212" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-213" class="mjx-msup"><span class="mjx-base"><span id="MJXc-Node-214" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.584em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-215" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span></span><span id="MJXc-Node-216" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">)</span></span></span><span id="MJXc-Node-217" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">)</span></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-11-Frame" class="mjx-chtml"><span id="MJXc-Node-218" class="mjx-math"><span id="MJXc-Node-219" class="mjx-mrow"><span id="MJXc-Node-220" class="mjx-mstyle"><span id="MJXc-Node-221" class="mjx-mrow"><span id="MJXc-Node-222" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.182em;">Y</span></span><span id="MJXc-Node-223" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-224" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-225" class="mjx-mrow"><span id="MJXc-Node-226" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-227" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;">z</span></span></span><span id="MJXc-Node-228" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-229" class="mjx-mrow"><span id="MJXc-Node-230" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-231" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-232" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span><span id="MJXc-Node-233" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-234" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-235" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-236" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-237" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-238" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-239" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-240" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-241" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-242" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span><span id="MJXc-Node-243" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-244" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-245" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span><span id="MJXc-Node-246" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-247" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-248" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">1</span></span><span id="MJXc-Node-249" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-250" class="mjx-mrow"><span id="MJXc-Node-251" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-252" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-253" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-254" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-255" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-256" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-257" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-258" class="mjx-msup"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-259" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.584em; padding-left: 0.082em; padding-right: 0.071em;"><span id="MJXc-Node-260" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span></span><span id="MJXc-Node-261" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">)</span></span></span><span id="MJXc-Node-262" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">)</span></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-12-Frame" class="mjx-chtml"><span id="MJXc-Node-263" class="mjx-math"><span id="MJXc-Node-264" class="mjx-mrow"><span id="MJXc-Node-265" class="mjx-mstyle"><span id="MJXc-Node-266" class="mjx-mrow"><span id="MJXc-Node-267" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.04em;">Z</span></span><span id="MJXc-Node-268" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-269" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-270" class="mjx-mrow"><span id="MJXc-Node-271" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span id="MJXc-Node-272" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;">z</span></span></span></span></span></span></span></span>
-            </p>
-          </li>
-        </ul>
-        <p class="note">
-          See depth_deproject function in <a>3D point cloud rendering</a>
-          example.
-        </p>
-      </section>
-      <section>
-        <h2>
-          Transform from depth to color 3D space
-        </h2>
-        <p>
-          The result of <a>project</a> depth value to 3D point step, 3D point
-          (Xd, Yd, Zd), is in depth camera 3D coordinate system. To
-          <dfn>transform</dfn> coordinates of the same point in space, but to
-          color camera 3D coordinate system, we use matrix multiplication of
-          <a>transformation from depth to video</a> matrix by the (Xd, Yd, Zd)
-          3D point vector.
-        </p>
-        <p>
-          Let (Xc, Yc, Zc) be the output of this step - a 3D coordinates of
-          projected <a>depth map value</a> to color camera 3D space.
-        </p>
-        <p>
-          Let <var>M</var> be <a>transformation matrix</a> defined in <a>depth
-          map</a>'s <a data-link-for="MediaTrackSettings">depthToVideoTransform</a> field.
-        </p>
-        <p>
-          To multiply 4x4 matrix by 3 element vector, we extend the 3D vector
-          by one element to 4 dimensional vector. After multiplication, we use
-          vector's x, y and z coordinates as the result.
-        </p>
-        <p>
-          <span id="MathJax-Element-13-Frame" class="mjx-chtml"><span id="MJXc-Node-273" class="mjx-math"><span id="MJXc-Node-274" class="mjx-mrow"><span id="MJXc-Node-275" class="mjx-mstyle"><span id="MJXc-Node-276" class="mjx-mrow"><span id="MJXc-Node-277" class="mjx-mrow"><span id="MJXc-Node-278" class="mjx-mo" style="vertical-align: -1.023em;"><span class="mjx-delim-v"><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.961em;">⎛</span><span class="mjx-char MJXc-TeX-size4-R" style="line-height: 0.266em; margin-bottom: -0.1em; margin-top: 0px;">⎜</span><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.888em;">⎝</span></span></span><span id="MJXc-Node-279" class="mjx-mtable" style="vertical-align: -1.692em; padding: 0px 0.167em;"><span class="mjx-table"><span id="MJXc-Node-280" class="mjx-mtr" style="height: 1.221em;"><span id="MJXc-Node-281" class="mjx-mtd" style="padding: 0px 0px 0px 0px; width: 1.285em;"><span id="MJXc-Node-282" class="mjx-mrow" style="margin-top: -0.2em;"><span id="MJXc-Node-283" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;">X</span></span><span id="MJXc-Node-284" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span class="mjx-strut"></span></span></span></span><span id="MJXc-Node-285" class="mjx-mtr" style="height: 1.442em;"><span id="MJXc-Node-286" class="mjx-mtd" style="padding: 0.221em 0px 0px 0px;"><span id="MJXc-Node-287" class="mjx-mrow" style="margin-top: -0.2em;"><span id="MJXc-Node-288" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.182em;">Y</span></span><span id="MJXc-Node-289" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span class="mjx-strut"></span></span></span></span><span id="MJXc-Node-290" class="mjx-mtr" style="height: 1.221em;"><span id="MJXc-Node-291" class="mjx-mtd" style="padding: 0.221em 0px 0px 0px;"><span id="MJXc-Node-292" class="mjx-mrow" style="margin-top: -0.2em;"><span id="MJXc-Node-293" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.04em;">Z</span></span><span id="MJXc-Node-294" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span class="mjx-strut"></span></span></span></span></span></span><span id="MJXc-Node-295" class="mjx-mo" style="vertical-align: -1.023em;"><span class="mjx-delim-v"><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.961em;">⎞</span><span class="mjx-char MJXc-TeX-size4-R" style="line-height: 0.266em; margin-bottom: -0.1em; margin-top: 0px;">⎟</span><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.888em;">⎠</span></span></span></span><span id="MJXc-Node-296" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-297" class="mjx-mrow"><span id="MJXc-Node-298" class="mjx-mo" style="vertical-align: -1.744em;"><span class="mjx-delim-v"><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.961em;">⎛</span><span class="mjx-char MJXc-TeX-size4-R" style="line-height: 0.569em; margin-bottom: -0.1em; margin-top: 0px;">⎜
-⎜
-⎜</span><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.888em;">⎝</span></span></span><span id="MJXc-Node-299" class="mjx-mrow"><span id="MJXc-Node-300" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.446em; padding-bottom: 0.593em;">[</span></span><span id="MJXc-Node-301" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.081em;">M</span></span><span id="MJXc-Node-302" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.446em; padding-bottom: 0.593em;">]</span></span></span><span id="MJXc-Node-303" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.225em; padding-bottom: 0.298em;">×</span></span><span id="MJXc-Node-304" class="mjx-mrow"><span id="MJXc-Node-305" class="mjx-mo" style="vertical-align: -1.744em;"><span class="mjx-delim-v"><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.961em;">⎛</span><span class="mjx-char MJXc-TeX-size4-R" style="line-height: 0.569em; margin-bottom: -0.1em; margin-top: 0px;">⎜
-⎜
-⎜</span><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.888em;">⎝</span></span></span><span id="MJXc-Node-306" class="mjx-mtable" style="vertical-align: -2.413em; padding: 0px 0.167em;"><span class="mjx-table"><span id="MJXc-Node-307" class="mjx-mtr" style="height: 1.221em;"><span id="MJXc-Node-308" class="mjx-mtd" style="padding: 0px 0px 0px 0px; width: 1.375em;"><span id="MJXc-Node-309" class="mjx-mrow" style="margin-top: -0.2em;"><span id="MJXc-Node-310" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;">X</span></span><span id="MJXc-Node-311" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span class="mjx-strut"></span></span></span></span><span id="MJXc-Node-312" class="mjx-mtr" style="height: 1.442em;"><span id="MJXc-Node-313" class="mjx-mtd" style="padding: 0.221em 0px 0px 0px;"><span id="MJXc-Node-314" class="mjx-mrow" style="margin-top: -0.2em;"><span id="MJXc-Node-315" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.182em;">Y</span></span><span id="MJXc-Node-316" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span class="mjx-strut"></span></span></span></span><span id="MJXc-Node-317" class="mjx-mtr" style="height: 1.442em;"><span id="MJXc-Node-318" class="mjx-mtd" style="padding: 0.221em 0px 0px 0px;"><span id="MJXc-Node-319" class="mjx-mrow" style="margin-top: -0.2em;"><span id="MJXc-Node-320" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.04em;">Z</span></span><span id="MJXc-Node-321" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.003em;">d</span></span><span class="mjx-strut"></span></span></span></span><span id="MJXc-Node-322" class="mjx-mtr" style="height: 1.221em;"><span id="MJXc-Node-323" class="mjx-mtd" style="padding: 0.221em 0px 0px 0px;"><span id="MJXc-Node-324" class="mjx-mrow" style="margin-top: -0.2em;"><span id="MJXc-Node-325" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">1</span></span><span class="mjx-strut"></span></span></span></span></span></span><span id="MJXc-Node-326" class="mjx-mo" style="vertical-align: -1.744em;"><span class="mjx-delim-v"><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.961em;">⎞</span><span class="mjx-char MJXc-TeX-size4-R" style="line-height: 0.569em; margin-bottom: -0.1em; margin-top: 0px;">⎟
-⎟
-⎟</span><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.888em;">⎠</span></span></span></span><span id="MJXc-Node-327" class="mjx-mo" style="vertical-align: -1.744em;"><span class="mjx-delim-v"><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.961em;">⎞</span><span class="mjx-char MJXc-TeX-size4-R" style="line-height: 0.569em; margin-bottom: -0.1em; margin-top: 0px;">⎟
-⎟
-⎟</span><span class="mjx-char MJXc-TeX-size4-R" style="padding-top: 0.961em; padding-bottom: 0.888em;">⎠</span></span></span></span><span id="MJXc-Node-328" class="mjx-mo" style="padding-right: 0.222em;"><span class="mjx-char MJXc-TeX-main-R" style="margin-top: -0.144em; padding-bottom: 0.372em;">.</span></span><span id="MJXc-Node-329" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span><span id="MJXc-Node-330" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span><span id="MJXc-Node-331" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em; padding-right: 0.003em;">z</span></span></span></span></span></span></span>
-        </p>
-        <p class="note">
-          In <a>3D point cloud rendering</a> example, this is done by:
-          <code>vec4 color_point = u_depth_to_color * vec4(depth_point,
-          1.0);</code>
-        </p>
-      </section>
-      <section>
-        <h2>
-          Project from color 3D to pixel
-        </h2>
-        <p>
-          To <dfn>project</dfn> from color 3D to 2D coordinate we use the
-          corresponding color track's <a href="#mediatracksettings-dictionary">MediaTrackSettings</a>. The color
-          track we get using <a>depth map</a>'s <a data-link-for="MediaTrackSettings">Transformation</a>.<a>videoDeviceId</a> - it
-          represents the target color video deviceID that should be used as a
-          constraint with [[!GETUSERMEDIA]] call to get the corresponding color
-          video stream track. After that, we use color track
-          <a>getSettings()</a> to access <a href="#mediatracksettings-dictionary">MediaTrackSettings</a>.
-        </p>
-        <p>
-          Let <span id="MathJax-Element-14-Frame" class="mjx-chtml"><span id="MJXc-Node-332" class="mjx-math"><span id="MJXc-Node-333" class="mjx-mrow"><span id="MJXc-Node-334" class="mjx-mstyle"><span id="MJXc-Node-335" class="mjx-mrow"><span id="MJXc-Node-336" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-337" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-338" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-339" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span></span></span></span></span></span> and <span id="MathJax-Element-15-Frame" class="mjx-chtml"><span id="MJXc-Node-340" class="mjx-math"><span id="MJXc-Node-341" class="mjx-mrow"><span id="MJXc-Node-342" class="mjx-mstyle"><span id="MJXc-Node-343" class="mjx-mrow"><span id="MJXc-Node-344" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-345" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-346" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-347" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span></span></span></span></span></span> be color track's <a>horizontal focal length</a>
-          and <a>vertical focal length</a> respectively.
-        </p>
-        <p>
-          Let <span id="MathJax-Element-16-Frame" class="mjx-chtml"><span id="MJXc-Node-348" class="mjx-math"><span id="MJXc-Node-349" class="mjx-mrow"><span id="MJXc-Node-350" class="mjx-mstyle"><span id="MJXc-Node-351" class="mjx-mrow"><span id="MJXc-Node-352" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span id="MJXc-Node-353" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-354" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-355" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span></span></span></span></span></span> and <span id="MathJax-Element-17-Frame" class="mjx-chtml"><span id="MJXc-Node-356" class="mjx-math"><span id="MJXc-Node-357" class="mjx-mrow"><span id="MJXc-Node-358" class="mjx-mstyle"><span id="MJXc-Node-359" class="mjx-mrow"><span id="MJXc-Node-360" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span id="MJXc-Node-361" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-362" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-363" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span></span></span></span></span></span> be color track's <a>principal point</a> 2D
-          coordinates.
-        </p>
-        <p>
-          The result of this step is 2D coordinate of pixel in color video
-          frame (<var>x</var>, <var>y</var>).
-        </p>
-        <ul>
-          <li>If color track's <a>projection distortion coefficients</a>
-          <a>k1</a>, <a>k2</a>, <a>k3</a>, <a>p1</a> and <a>p2</a> are
-          <a>present</a> in <a href="#mediatracksettings-dictionary">MediaTrackSettings</a> dictionary,
-            <p>
-              position of pixel in color frame image (x, y) is calculated as:
-            </p>
-            <p>
-              <span id="MathJax-Element-18-Frame" class="mjx-chtml"><span id="MJXc-Node-364" class="mjx-math"><span id="MJXc-Node-365" class="mjx-mrow"><span id="MJXc-Node-366" class="mjx-mstyle"><span id="MJXc-Node-367" class="mjx-mrow"><span id="MJXc-Node-368" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-369" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-370" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-371" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-372" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-373" class="mjx-msup"><span class="mjx-base"><span id="MJXc-Node-374" class="mjx-mrow"><span id="MJXc-Node-375" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.446em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-376" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;">X</span></span><span id="MJXc-Node-377" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span id="MJXc-Node-378" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.446em; padding-bottom: 0.593em;">)</span></span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.71em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-379" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span></span><span id="MJXc-Node-380" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-381" class="mjx-msup"><span class="mjx-base"><span id="MJXc-Node-382" class="mjx-mrow"><span id="MJXc-Node-383" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.446em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-384" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.182em;">Y</span></span><span id="MJXc-Node-385" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span id="MJXc-Node-386" class="mjx-mo"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.446em; padding-bottom: 0.593em;">)</span></span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.71em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-387" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-19-Frame" class="mjx-chtml"><span id="MJXc-Node-388" class="mjx-math"><span id="MJXc-Node-389" class="mjx-mrow"><span id="MJXc-Node-390" class="mjx-mstyle"><span id="MJXc-Node-391" class="mjx-mrow"><span id="MJXc-Node-392" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-393" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-394" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">1</span></span><span id="MJXc-Node-395" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-396" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em;">k</span></span><span id="MJXc-Node-397" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">1</span></span><span id="MJXc-Node-398" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-399" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-400" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-401" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-402" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em;">k</span></span><span id="MJXc-Node-403" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-404" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-405" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-406" class="mjx-msup"><span class="mjx-base"><span id="MJXc-Node-407" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.591em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-408" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span></span><span id="MJXc-Node-409" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-410" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em;">k</span></span><span id="MJXc-Node-411" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">3</span></span><span id="MJXc-Node-412" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-413" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-414" class="mjx-msup"><span class="mjx-base"><span id="MJXc-Node-415" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span><span class="mjx-sup" style="font-size: 70.7%; vertical-align: 0.591em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-416" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">3</span></span></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-20-Frame" class="mjx-chtml"><span id="MJXc-Node-417" class="mjx-math"><span id="MJXc-Node-418" class="mjx-mrow"><span id="MJXc-Node-419" class="mjx-mstyle"><span id="MJXc-Node-420" class="mjx-mrow"><span id="MJXc-Node-421" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-422" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-423" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-424" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-425" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-426" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-427" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-428" class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style="width: 1.485em; padding: 0px 0.12em;"><span class="mjx-numerator" style="width: 1.485em; top: -1.385em;"><span id="MJXc-Node-429" class="mjx-mrow"><span id="MJXc-Node-430" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;">X</span></span><span id="MJXc-Node-431" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span class="mjx-denominator" style="width: 1.485em; bottom: -0.784em;"><span id="MJXc-Node-432" class="mjx-mrow"><span id="MJXc-Node-433" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.04em;">Z</span></span><span id="MJXc-Node-434" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 1.485em;" class="mjx-line"></span></span><span style="height: 2.169em; vertical-align: -0.784em;" class="mjx-vsize"></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-21-Frame" class="mjx-chtml"><span id="MJXc-Node-435" class="mjx-math"><span id="MJXc-Node-436" class="mjx-mrow"><span id="MJXc-Node-437" class="mjx-mstyle"><span id="MJXc-Node-438" class="mjx-mrow"><span id="MJXc-Node-439" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-440" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-441" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-442" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-443" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-444" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-445" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-446" class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style="width: 1.396em; padding: 0px 0.12em;"><span class="mjx-numerator" style="width: 1.396em; top: -1.385em;"><span id="MJXc-Node-447" class="mjx-mrow"><span id="MJXc-Node-448" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.182em;">Y</span></span><span id="MJXc-Node-449" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span class="mjx-denominator" style="width: 1.396em; bottom: -0.784em;"><span id="MJXc-Node-450" class="mjx-mrow"><span id="MJXc-Node-451" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.04em;">Z</span></span><span id="MJXc-Node-452" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 1.396em;" class="mjx-line"></span></span><span style="height: 2.169em; vertical-align: -0.784em;" class="mjx-vsize"></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-22-Frame" class="mjx-chtml"><span id="MJXc-Node-453" class="mjx-math"><span id="MJXc-Node-454" class="mjx-mrow"><span id="MJXc-Node-455" class="mjx-mstyle"><span id="MJXc-Node-456" class="mjx-mrow"><span id="MJXc-Node-457" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span><span id="MJXc-Node-458" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-459" class="mjx-mrow"><span id="MJXc-Node-460" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-461" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-462" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-463" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-464" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-465" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-466" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-467" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-468" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-469" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">1</span></span><span id="MJXc-Node-470" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-471" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-472" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-473" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-474" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-475" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-476" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-477" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-478" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-479" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-480" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-481" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-482" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-483" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-484" class="mjx-mrow"><span id="MJXc-Node-485" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-486" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-487" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-488" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-489" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-490" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-491" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-492" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-493" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-494" class="mjx-mrow"><span id="MJXc-Node-495" class="mjx-msubsup"><span class="mjx-base"><span id="MJXc-Node-496" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-stack" style="vertical-align: -0.157em;"><span class="mjx-sup" style="font-size: 70.7%; padding-bottom: 0.255em; padding-left: 0px; padding-right: 0.071em;"><span id="MJXc-Node-498" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span><span class="mjx-sub" style="font-size: 70.7%; padding-right: 0.071em;"><span id="MJXc-Node-497" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span></span></span><span id="MJXc-Node-499" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">)</span></span></span><span id="MJXc-Node-500" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">)</span></span></span><span id="MJXc-Node-501" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-502" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-503" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-504" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-505" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-506" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-507" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span id="MJXc-Node-508" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-509" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-510" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-23-Frame" class="mjx-chtml"><span id="MJXc-Node-511" class="mjx-math"><span id="MJXc-Node-512" class="mjx-mrow"><span id="MJXc-Node-513" class="mjx-mstyle"><span id="MJXc-Node-514" class="mjx-mrow"><span id="MJXc-Node-515" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span><span id="MJXc-Node-516" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-517" class="mjx-mrow"><span id="MJXc-Node-518" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-519" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-520" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-521" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-522" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-523" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-524" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-525" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-526" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-527" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-528" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-529" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-530" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-531" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-532" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-533" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-534" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-535" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-536" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-537" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-538" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-539" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-540" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">1</span></span><span id="MJXc-Node-541" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-542" class="mjx-mrow"><span id="MJXc-Node-543" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">(</span></span><span id="MJXc-Node-544" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">r</span></span><span id="MJXc-Node-545" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-546" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-547" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-548" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-549" class="mjx-mn"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span><span id="MJXc-Node-550" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-551" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-552" class="mjx-mrow"><span id="MJXc-Node-553" class="mjx-msubsup"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-554" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-stack" style="vertical-align: -0.157em;"><span class="mjx-sup" style="font-size: 70.7%; padding-bottom: 0.255em; padding-left: 0.082em; padding-right: 0.071em;"><span id="MJXc-Node-556" class="mjx-mn" style=""><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.372em; padding-bottom: 0.372em;">2</span></span></span><span class="mjx-sub" style="font-size: 70.7%; padding-right: 0.071em;"><span id="MJXc-Node-555" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span></span></span><span id="MJXc-Node-557" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">)</span></span></span><span id="MJXc-Node-558" class="mjx-mo"><span class="mjx-char MJXc-TeX-size1-R" style="padding-top: 0.593em; padding-bottom: 0.593em;">)</span></span></span><span id="MJXc-Node-559" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-560" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-561" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-562" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-563" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-564" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-565" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span id="MJXc-Node-566" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-567" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-568" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span></span></span></span></span></span>
-            </p>
-          </li>
-          <li>If color track's <a>projection distortion coefficients</a> are
-          <a>not present</a> in <a href="#mediatracksettings-dictionary">MediaTrackSettings</a> dictionary,
-            <p>
-              position of pixel in color frame image (x, y) is calculated as:
-            </p>
-            <p>
-              <span id="MathJax-Element-24-Frame" class="mjx-chtml"><span id="MJXc-Node-569" class="mjx-math"><span id="MJXc-Node-570" class="mjx-mrow"><span id="MJXc-Node-571" class="mjx-mstyle"><span id="MJXc-Node-572" class="mjx-mrow"><span id="MJXc-Node-573" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-574" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-575" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-576" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-577" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-578" class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style="width: 1.485em; padding: 0px 0.12em;"><span class="mjx-numerator" style="width: 1.485em; top: -1.385em;"><span id="MJXc-Node-579" class="mjx-mrow"><span id="MJXc-Node-580" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.024em;">X</span></span><span id="MJXc-Node-581" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span class="mjx-denominator" style="width: 1.485em; bottom: -0.784em;"><span id="MJXc-Node-582" class="mjx-mrow"><span id="MJXc-Node-583" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.04em;">Z</span></span><span id="MJXc-Node-584" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 1.485em;" class="mjx-line"></span></span><span style="height: 2.169em; vertical-align: -0.784em;" class="mjx-vsize"></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-25-Frame" class="mjx-chtml"><span id="MJXc-Node-585" class="mjx-math"><span id="MJXc-Node-586" class="mjx-mrow"><span id="MJXc-Node-587" class="mjx-mstyle"><span id="MJXc-Node-588" class="mjx-mrow"><span id="MJXc-Node-589" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-590" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-591" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-592" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-593" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-594" class="mjx-mfrac"><span class="mjx-box MJXc-stacked" style="width: 1.396em; padding: 0px 0.12em;"><span class="mjx-numerator" style="width: 1.396em; top: -1.385em;"><span id="MJXc-Node-595" class="mjx-mrow"><span id="MJXc-Node-596" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.182em;">Y</span></span><span id="MJXc-Node-597" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span class="mjx-denominator" style="width: 1.396em; bottom: -0.784em;"><span id="MJXc-Node-598" class="mjx-mrow"><span id="MJXc-Node-599" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.446em; padding-bottom: 0.298em; padding-right: 0.04em;">Z</span></span><span id="MJXc-Node-600" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span style="border-bottom: 1.3px solid; top: -0.296em; width: 1.396em;" class="mjx-line"></span></span><span style="height: 2.169em; vertical-align: -0.784em;" class="mjx-vsize"></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-26-Frame" class="mjx-chtml"><span id="MJXc-Node-601" class="mjx-math"><span id="MJXc-Node-602" class="mjx-mrow"><span id="MJXc-Node-603" class="mjx-mstyle"><span id="MJXc-Node-604" class="mjx-mrow"><span id="MJXc-Node-605" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span><span id="MJXc-Node-606" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-607" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-608" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-609" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-610" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-611" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-612" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-613" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-614" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-615" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-616" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-617" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span id="MJXc-Node-618" class="mjx-msub"><span class="mjx-base"><span id="MJXc-Node-619" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">x</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-620" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span></span></span></span></span></span>
-            </p>
-            <p>
-              <span id="MathJax-Element-27-Frame" class="mjx-chtml"><span id="MJXc-Node-621" class="mjx-math"><span id="MJXc-Node-622" class="mjx-mrow"><span id="MJXc-Node-623" class="mjx-mstyle"><span id="MJXc-Node-624" class="mjx-mrow"><span id="MJXc-Node-625" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span><span id="MJXc-Node-626" class="mjx-mo" style="padding-left: 0.333em; padding-right: 0.333em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.077em; padding-bottom: 0.298em;">=</span></span><span id="MJXc-Node-627" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.446em;">p</span></span><span id="MJXc-Node-628" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-629" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-630" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-631" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.004em; padding-bottom: 0.298em;">⋅</span></span><span id="MJXc-Node-632" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.519em; padding-bottom: 0.519em; padding-right: 0.06em;">f</span></span><span id="MJXc-Node-633" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-634" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-635" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span><span id="MJXc-Node-636" class="mjx-mo" style="padding-left: 0.267em; padding-right: 0.267em;"><span class="mjx-char MJXc-TeX-main-R" style="padding-top: 0.298em; padding-bottom: 0.446em;">+</span></span><span id="MJXc-Node-637" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span><span id="MJXc-Node-638" class="mjx-msub"><span class="mjx-base" style="margin-right: -0.006em;"><span id="MJXc-Node-639" class="mjx-mi"><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.519em; padding-right: 0.006em;">y</span></span></span><span class="mjx-sub" style="font-size: 70.7%; vertical-align: -0.212em; padding-right: 0.071em;"><span id="MJXc-Node-640" class="mjx-mi" style=""><span class="mjx-char MJXc-TeX-math-I" style="padding-top: 0.225em; padding-bottom: 0.298em;">c</span></span></span></span></span></span></span></span></span>
-            </p>
-          </li>
-        </ul>
-        <p class="note">
-          See color_project function in <a>3D point cloud rendering</a>
-          example.
-        </p>
-      </section>
-    </section>
-    <section class="informative">
-      <h2>
-        Examples
-      </h2>
-      <h3>
-        Playback of depth and color streams from same device group.
-      </h3>
-      <pre class="example">navigator.mediaDevices.getUserMedia({
+        <h3>
+          Playback of depth and color streams from same device group.
+        </h3>
+        <pre class="example">navigator.mediaDevices.getUserMedia({
   video: {videoKind: {exact: "color"}, groupId: {exact: id}}
 }).then(function (stream) {
     // Wire the media stream into a &lt;video&gt; element for playback.
@@ -1317,14 +574,14 @@ navigator.mediaDevices.getUserMedia({
   }
 );
 </pre>
-      <h3>
-        WebGL: <dfn>upload to float texture</dfn>
-      </h3>
-      <p>
-        This code sets up a video element from a depth stream, uploads it to a
-        WebGL 2.0 float texture.
-      </p>
-      <pre class="example">navigator.mediaDevices.getUserMedia({
+        <h3>
+          WebGL: <dfn>upload to float texture</dfn>
+        </h3>
+        <p>
+          This code sets up a video element from a depth stream, uploads it to
+          a WebGL 2.0 float texture.
+        </p>
+        <pre class="example">navigator.mediaDevices.getUserMedia({
   video: {videoKind: {exact: "depth"}}
 }).then(function (stream) {
   // wire the stream into a &lt;video&gt; element for playback
@@ -1351,19 +608,19 @@ gl.texImage2D(
    depthVideo);
 
 </pre>
-      <h3>
-        WebGL: <dfn>readPixels from float</dfn> texture
-      </h3>
-      <p>
-        This example extends <a>upload to float texture</a> example.
-      </p>
-      <p>
-        This code creates the texture to which we will upload the depth video
-        frame. Then, it sets up a named framebuffer, attach the texture as
-        color attachment and, after uploading the depth video to the texture,
-        reads the texture content to Float32Array.
-      </p>
-      <pre class="example">// Initialize texture and framebuffer for reading back the texture.
+        <h3>
+          WebGL: <dfn>readPixels from float</dfn> texture
+        </h3>
+        <p>
+          This example extends <a>upload to float texture</a> example.
+        </p>
+        <p>
+          This code creates the texture to which we will upload the depth video
+          frame. Then, it sets up a named framebuffer, attach the texture as
+          color attachment and, after uploading the depth video to the texture,
+          reads the texture content to Float32Array.
+        </p>
+        <pre class="example">// Initialize texture and framebuffer for reading back the texture.
 let depthTexture = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, depthTexture);
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
@@ -1407,123 +664,37 @@ gl.readPixels(
   buffer);
 
 </pre>
-      <div class="note">
+        <div class="note">
+          <p>
+            Use
+            <code>gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT);</code>
+            to check whether readPixels to gl.RED or gl.RGBA float is
+            supported.
+          </p>
+        </div>
+      </section>
+      <section class="informative">
+        <h2>
+          Privacy and security considerations
+        </h2>
         <p>
-          Use
-          <code>gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT);</code> to
-          check whether readPixels to gl.RED or gl.RGBA float is supported.
+          The <a href="https://w3c.github.io/mediacapture-main/#privacy-and-security-considerations">
+          privacy and security considerations</a> discussed in
+          [[!GETUSERMEDIA]] apply to this extension specification.
         </p>
-      </div>
-      <h3>
-        WebGL Vertex Shader that implements mapping color and depth
-      </h3>
-      <p>
-        This vertex shader is used for <dfn>3D point cloud rendering</dfn>. The
-        code here shows how the web developer can implement <a>algorithm to map
-        depth pixels to color pixels</a>. Draw call used is
-        glDrawArrays(GL_POINTS, 0, depthMap.width * depthMap.height). Shader
-        output is 3D position of vertices (gl_Position) and color texture
-        sampling coordinates per vertex.
-      </p>
-      <pre class="example">&lt;script id="fragment-shader" type="x-shader/x-fragment"&gt;#version 300 es
-#define DISTORTION_NONE 0
-#define USE_DEPTH_DEPROJECTION_DISTORTION_COEFFICIENTS 1
-#define USE_COLOR_PROJECTION_DISTORTION_COEFFICIENTS 2
-uniform mat4 u_mvp;
-uniform vec2 u_color_size;
-uniform vec2 u_depth_size;
-uniform highp usampler2D s_depth_texture;
-uniform float u_depth_scale_in_meter;
-uniform mat4 u_depth_to_color;
-uniform vec2 u_color_offset;
-uniform vec2 u_color_focal_length;
-uniform float u_color_coeffs[5];
-uniform int u_color_projection_distortion;
-uniform vec2 u_depth_offset;
-uniform vec2 u_depth_focal_length;
-uniform float u_depth_coeffs[5];
-uniform int u_depth_deprojection_distortion;
-out vec2 v_tex;
-
-vec3 depth_deproject(vec2 pixel, float depth)
-{
-  vec2 point = (pixel - u_depth_offset) / u_depth_focal_length;
-  if(u_depth_deprojection_distortion == USE_DEPTH_DEPROJECTION_DISTORTION_COEFFICIENTS)
-  {
-    float r2 = dot(point, point);
-    float f = 1.0 + u_depth_coeffs[0] * r2 + u_depth_coeffs[1] * r2 * r2 + u_depth_coeffs[4] * r2 * r2 * r2;
-    float ux = point.x * f + 2.0 * u_depth_coeffs[2] * point.x * point.y +
-               u_depth_coeffs[3] * (r2 + 2.0 * point.x * point.x);
-    float uy = point.y * f + 2.0 * u_depth_coeffs[3] * point.x * point.y +
-               u_depth_coeffs[2] * (r2 + 2.0 * point.y * point.y);
-    point = vec2(ux, uy);
-  }
-  return vec3(point * depth, depth);
-}
-
-vec2 color_project(vec3 point)
-{
-  vec2 pixel = point.xy / point.z;
-  if(u_color_projection_distortion == USE_COLOR_PROJECTION_DISTORTION_COEFFICIENTS)
-  {
-    float r2 = dot(pixel, pixel);
-    float f = 1.0 + u_color_coeffs[0] * r2 + u_color_coeffs[1] * r2 * r2 +
-              u_color_coeffs[4] * r2 * r2 * r2;
-    pixel = pixel * f;
-    float dx = pixel.x + 2.0 * u_color_coeffs[2] * pixel.x * pixel.y +
-               u_color_coeffs[3] * (r2 + 2.0 * pixel.x * pixel.x);
-    float dy = pixel.y + 2.0 * u_color_coeffs[3] * pixel.x * pixel.y +
-               u_color_coeffs[2] * (r2 + 2.0 * pixel.y * pixel.y);
-    pixel = vec2(dx, dy);
-  }
-  return pixel * u_color_focal_length + u_color_offset;
-}
-
-void main()
-{
-  vec2 depth_pixel;
-  // generate lattice pos; (0, 0) (1, 0) (2, 0) ... (w-1, h-1)
-  depth_pixel.x = mod(float(gl_VertexID) + 0.5, u_depth_size.x);
-  depth_pixel.y = clamp(floor(float(gl_VertexID) / u_depth_size.x) + 0.5, 0.0, u_depth_size.y);
-
-  // get depth
-  vec2 depth_tex_pos = depth_pixel / u_depth_size;
-  uint depth = texture(s_depth_texture, depth_tex_pos).r;
-  float depth_in_meter = float(depth) * u_depth_scale_in_meter;
-
-  vec3 depth_point = depth_deproject(depth_pixel, depth_in_meter);
-  vec4 color_point = u_depth_to_color * vec4(depth_point, 1.0);
-  vec2 color_pixel = color_project(color_point.xyz);
-
-  // map [0, w) to [0, 1]
-  v_tex = color_pixel / u_color_size;
-
-  gl_Position = u_mvp * vec4(depth_point, 1.0);
-}
-&lt;/script&gt;
-</pre>
+      </section>
+      <section class="appendix">
+        <h2>
+          Acknowledgements
+        </h2>
+        <p>
+          Thanks to everyone who contributed to the <a href="https://www.w3.org/wiki/Media_Capture_Depth_Stream_Extension">Use
+          Cases and Requirements</a>, sent feedback and comments. Special
+          thanks to Ningxin Hu for experimental implementations, as well as to
+          the Project Tango for their experiments.
+        </p>
+      </section><!--section id="idl-index" class="appendix"></section-->
     </section>
-    <section class="informative">
-      <h2>
-        Privacy and security considerations
-      </h2>
-      <p>
-        The <a href="https://w3c.github.io/mediacapture-main/#privacy-and-security-considerations">
-        privacy and security considerations</a> discussed in [[!GETUSERMEDIA]]
-        apply to this extension specification.
-      </p>
-    </section>
-    <section class="appendix">
-      <h2>
-        Acknowledgements
-      </h2>
-      <p>
-        Thanks to everyone who contributed to the <a href="https://www.w3.org/wiki/Media_Capture_Depth_Stream_Extension">Use
-        Cases and Requirements</a>, sent feedback and comments. Special thanks
-        to Ningxin Hu for experimental implementations, as well as to the
-        Project Tango for their experiments.
-      </p>
-    </section><!--section id="idl-index" class="appendix"></section-->
   
 
 </body></html>

--- a/index.html
+++ b/index.html
@@ -223,14 +223,12 @@
       </p>
       <p>
         The <dfn data-cite="!GETUSERMEDIA#dom-mediadevices-getusermedia"><code>getUserMedia()</code></dfn>
-        and the <dfn data-cite="!GETUSERMEDIA#idl-def-NavigatorUserMediaSuccessCallback"><code>NavigatorUserMediaSuccessCallback</code></dfn>
-        callback are defined in [[!GETUSERMEDIA]].
+        is defined in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The concepts <dfn data-cite="!GETUSERMEDIA#track-muted">muted</dfn>,
-        <dfn data-cite="!GETUSERMEDIA#track-enabled">disabled</dfn>, and
-        <dfn data-cite="!GETUSERMEDIA#event-mediastreamtrack-overconstrained"><code>overconstrained</code></dfn>
-        as applied to <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
+        The concepts <dfn data-cite="!GETUSERMEDIA#track-muted">muted</dfn> and
+        <dfn data-cite="!GETUSERMEDIA#track-enabled">disabled</dfn> as applied
+        to <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
         The terms <dfn data-cite="!GETUSERMEDIA#dfn-source">source</dfn> and
@@ -243,25 +241,12 @@
       </p>
       <p>
         The <dfn data-cite="!HTML#the-video-element"><code>video</code></dfn>
-        element, <dfn data-cite="!HTML#canvas-pixel-arraybuffer">Canvas Pixel
-        <code>ArrayBuffer</code></dfn>, <dfn data-cite="!HTML#videotrack"><code>VideoTrack</code></dfn>, <dfn data-cite="!HTML#htmlmediaelement"><code>HTMLMediaElement</code></dfn> (and its
-        <dfn data-cite="!HTML#dom-media-srcobject"><code>srcObject</code></dfn>
-        attribute), <dfn data-cite="!HTML#htmlvideoelement"><code>HTMLVideoElement</code></dfn> interfaces
-        and the <dfn data-cite="!HTML#canvasimagesource"><code>CanvasImageSource</code></dfn> enum are
-        defined in [[!HTML]].
+        element and <dfn data-cite="!HTML#canvas-pixel-arraybuffer">Canvas
+        Pixel <code>ArrayBuffer</code></dfn> interfaces are defined in
+        [[!HTML]].
       </p>
       <p>
-        The term <dfn data-cite="!PERMISSIONS#permission">permission</dfn> and
-        the permission name "<dfn data-cite="!PERMISSIONS#dom-permissionname-camera"><code>camera</code></dfn>" are
-        defined in [[!PERMISSIONS]].
-      </p>
-      <p>
-        The <dfn data-cite="!WEBIDL#idl-Float32Array"><code>Float32Array</code></dfn> buffer
-        source type is defined in [[WEBIDL]].
-      </p>
-      <p>
-        The meaning of dictionary member being <dfn data-cite="!WEBIDL#dfn-present">present</dfn> or <dfn data-cite="!WEBIDL#dfn-present">not present</dfn>, and its <dfn data-cite="!WEBIDL#dfn-dictionary-member-default-value">default value</dfn> are
-        defined in [[WEBIDL]].
+        The meaning of dictionary member being <dfn data-cite="!WEBIDL#dfn-present">present</dfn> or <dfn data-cite="!WEBIDL#dfn-present">not present</dfn> is defined in [[WEBIDL]].
       </p>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -222,9 +222,8 @@
         [[!GETUSERMEDIA]].
       </p>
       <p>
-        The <dfn data-cite="!GETUSERMEDIA#dom-mediadevices-getusermedia"><code>getUserMedia()</code></dfn>,
-        <dfn data-cite="!GETUSERMEDIA#dfn-getsettings"><code>getSettings()</code></dfn>
-        methods and the <dfn data-cite="!GETUSERMEDIA#idl-def-NavigatorUserMediaSuccessCallback"><code>NavigatorUserMediaSuccessCallback</code></dfn>
+        The <dfn data-cite="!GETUSERMEDIA#dom-mediadevices-getusermedia"><code>getUserMedia()</code></dfn>
+        and the <dfn data-cite="!GETUSERMEDIA#idl-def-NavigatorUserMediaSuccessCallback"><code>NavigatorUserMediaSuccessCallback</code></dfn>
         callback are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
@@ -244,20 +243,12 @@
       </p>
       <p>
         The <dfn data-cite="!HTML#the-video-element"><code>video</code></dfn>
-        element and <dfn data-cite="!HTML#imagedata"><code>ImageData</code></dfn> (and its <dfn data-cite="!HTML#dom-imagedata-data"><code>data</code></dfn> attribute and
-        <dfn data-cite="!HTML#canvas-pixel-arraybuffer">Canvas Pixel
-        <code>ArrayBuffer</code></dfn>), <dfn data-cite="!HTML#videotrack"><code>VideoTrack</code></dfn>, <dfn data-cite="!HTML#htmlmediaelement"><code>HTMLMediaElement</code></dfn> (and its
+        element, <dfn data-cite="!HTML#canvas-pixel-arraybuffer">Canvas Pixel
+        <code>ArrayBuffer</code></dfn>, <dfn data-cite="!HTML#videotrack"><code>VideoTrack</code></dfn>, <dfn data-cite="!HTML#htmlmediaelement"><code>HTMLMediaElement</code></dfn> (and its
         <dfn data-cite="!HTML#dom-media-srcobject"><code>srcObject</code></dfn>
         attribute), <dfn data-cite="!HTML#htmlvideoelement"><code>HTMLVideoElement</code></dfn> interfaces
         and the <dfn data-cite="!HTML#canvasimagesource"><code>CanvasImageSource</code></dfn> enum are
         defined in [[!HTML]].
-      </p>
-      <p>
-        The terms <dfn data-cite="!HTML#media-data">media data</dfn>,
-        <dfn data-cite="!HTML#media-provider-object">media provider
-        object</dfn>, <dfn data-cite="!HTML#assigned-media-provider-object">assigned media provider
-        object</dfn>, and the concept <dfn data-cite="!HTML#potentially-playing">potentially playing</dfn> are defined in
-        [[!HTML]].
       </p>
       <p>
         The term <dfn data-cite="!PERMISSIONS#permission">permission</dfn> and
@@ -265,10 +256,8 @@
         defined in [[!PERMISSIONS]].
       </p>
       <p>
-        The <dfn data-cite="!WEBIDL#idl-DataView"><code>DataView</code></dfn>,
-        <dfn data-cite="!WEBIDL#idl-Uint8ClampedArray"><code>Uint8ClampedArray</code></dfn>,
-        and <code><dfn data-cite="!WEBIDL#idl-Uint16Array">Uint16Array</dfn></code> buffer source types
-        are defined in [[WEBIDL]].
+        The <dfn data-cite="!WEBIDL#idl-Float32Array"><code>Float32Array</code></dfn> buffer
+        source type is defined in [[WEBIDL]].
       </p>
       <p>
         The meaning of dictionary member being <dfn data-cite="!WEBIDL#dfn-present">present</dfn> or <dfn data-cite="!WEBIDL#dfn-present">not present</dfn>, and its <dfn data-cite="!WEBIDL#dfn-dictionary-member-default-value">default value</dfn> are

--- a/index.src.html
+++ b/index.src.html
@@ -127,7 +127,7 @@
       <p>
         This specification <a href=
         "https://w3c.github.io/mediacapture-main/#extensibility">extends</a>
-        the <em>Media Capture and Streams</em> specification [[!GETUSERMEDIA]]
+        the <em>Media Capture and Streams</em> specification [[GETUSERMEDIA]]
         to allow a <a>depth-only stream</a> or combined <a>depth+color
         stream</a> to be requested from the web platform using APIs familiar to
         web authors.
@@ -139,7 +139,7 @@
         constrainable property per <a href=
         "https://w3c.github.io/mediacapture-main/#extensibility">Extensibility</a>
         guidelines of the <em>Media Capture and Streams</em> specification
-        [[!GETUSERMEDIA]]. Horizontal reviews and feedback from early
+        [[GETUSERMEDIA]]. Horizontal reviews and feedback from early
         implementations of this specification are encouraged.
       </p>
     </section>
@@ -225,14 +225,8 @@
       </p>
       <p>
         The <dfn data-cite=
-        "!GETUSERMEDIA#idl-def-ConstrainDOMString"><code>ConstrainDOMString</code></dfn>,
-        <dfn data-cite=
-        "!GETUSERMEDIA#idl-def-ConstrainDouble"><code>ConstrainDouble</code></dfn>,
-        <dfn data-cite=
-        "!GETUSERMEDIA#idl-def-ConstrainBoolean"><code>ConstrainBoolean</code></dfn>,
-        and <dfn data-cite=
-        "!GETUSERMEDIA#idl-def-DoubleRange"><code>DoubleRange</code></dfn>
-        types are defined in [[!GETUSERMEDIA]].
+        "!GETUSERMEDIA#idl-def-ConstrainDOMString"><code>ConstrainDOMString</code></dfn>
+        type is defined in [[!GETUSERMEDIA]].
       </p>
       <p>
         <dfn data-cite=
@@ -376,116 +370,19 @@
         <p>
           <dfn>Normalized</dfn> <a>depth map value</a> means that it's range is
           from 0 to 1, where maximum <a>depth map value</a> of 1 corresponds to
-          distances equal to <a>far value</a>. Following the <a href=
-          "#dfn-calculate-depth-map-value">conversion between depth map value
-          and distance</a>, the minumum value of 0 would correspond to
-          distances equal to <a>near value</a>, but 0 has a special meaning -
-          it is an <dfn>invalid depth map value</dfn> and represents that the
-          user agent is unable to acquire depth information for the given pixel
-          for any reason. <a>Normalized</a> <a>depth map value</a> is
-          represented using <dfn>floating-point</dfn> or <dfn>unsigned
-          fixed-point</dfn> formats <a href=
+          distances equal to <a>far plane</a>. <a>Normalized</a> <a>depth map
+          value</a> is represented using <dfn>floating-point</dfn> or
+          <dfn>unsigned fixed-point</dfn> formats <a href=
           "https://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.5.pdf#subsection.2.1.6">
           [OpenGL ES 3.0.5]#subsection.2.1.6</a>.
         </p>
         <p>
-          A <a>depth map</a> has an associated <dfn>near value</dfn> which is a
-          double. It represents the minimum range in meters and it defines
-          <dfn>near plane</dfn> which is a plane perpendicular to camera
-          viewing direction on distance <a>near value</a> from the camera
-          origin.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>far value</dfn> which is a
-          double. It represents the maximum range in meters. It represents the
-          minimum range in meters and it defines <dfn>far plane</dfn> which is
-          a plane perpendicular to camera viewing direction on distance <a>far
-          value</a> from the camera origin.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>horizontal focal
-          length</dfn> which is a double. It represents the horizontal
-          <dfn>focal length</dfn> of the depth camera, in pixels.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>vertical focal length</dfn>
-          which is a double. It represents the vertical focal length of the
-          depth camera, in pixels.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>principal point</dfn>,
-          specified by <dfn>principal point x</dfn> and <dfn>principal point
-          y</dfn> coordinates which are double. It is a concept defined in the
-          pinhole camera model; a projection of perspective center to the image
-          plane.
-        </p>
-        <p>
-          A <a>depth map</a> has an associated <dfn>transformation from depth
-          to video</dfn>, which is a <dfn>transformation matrix</dfn>
-          represented by a <a>Transformation</a> dictionary. It is used to
-          translate position in depth camera 3D coordinate system to RGB video
-          stream's camera (identified by <dfn>videoDeviceId</dfn>) 3D
-          coordinate system. After projecting depth 2D pixel coordinates to 3D
-          space, we use this matrix to transform depth camera 3D space
-          coordinates to RGB video camera 3D space.
-        </p>
-        <p>
-          Both depth and color cameras usually introduce significant distortion
-          caused by the camera and lens. While in some cases, the effects are
-          not noticeable, these distortions cause errors in image analysis. To
-          map <a>depth map</a> pixel values to corresponding color video track
-          pixels, we use two <a>DistortionCoefficients</a> dictionaries:
-          <dfn>deprojection distortion coefficients</dfn> and <dfn>projection
-          distortion coefficients</dfn>.
-        </p>
-        <p>
-          <a>Deprojection distortion coefficients</a> are used for compensating
-          camera distortion when deprojecting 2D pixel coordinates to 3D space
-          coordinates. <a>Projection distortion coefficients</a> are used in
-          the opposite case, when projecting camera 3D space points to pixels.
-          One track doesn't have both of the coefficients specified. The most
-          common scenario is that the depth track has <a>deprojection
-          distortion coefficients</a> or that the color video track has
-          <a>projection distortion coefficients</a>. For the details, see
-          <a>algorithm to map depth pixels to color pixels</a>.
+          <a>Depth map</a>'s <dfn>near plane</dfn> and <dfn>far plane</dfn> are
+          concepts of 3D graphics that define camera viewing volume (view
+          frustum). Their definition is outside the scope of this
+          specification.
         </p>
       </section>
-    </section>
-    <section>
-      <h2>
-        Conversion between depth map value and distance
-      </h2>
-      <p>
-        A <a>depth map value</a> is a distance to <a>near plane</a>
-        <a>normalized</a> against the distance between <a href=
-        "#dfn-far-plane">far</a> and <a href="#dfn-near-plane">near</a> plane:
-      </p>
-      <ul>
-        <li>Let <var>near</var> be the the <a>near value</a>.
-        </li>
-        <li>Let <var>far</var> be the the <a>far value</a>.
-        </li>
-        <li>Let <var>d</var> be the the distance to <a>near plane</a>.
-        </li>
-        <li>Let <var>depth</var> be the the <a>depth map value</a>.
-        </li>
-        <li>The formula to <dfn>calculate depth map value</dfn>
-        <var>depth</var> for the given distance <var>d</var> is:
-          <p>
-            `depth = (d - n ear) / (far - n ear)`
-          </p>
-        </li>
-        <li>If the distance <var>d</var> is greater than <a>far value</a>, the
-        depth is <a>invalid depth map value</a>.
-        </li>
-        <li>The formula to <dfn>convert the depth map value to distance</dfn>
-        <var>d</var>, for a <a>depth map value</a> <var>depth</var>, is as
-        follows:
-          <p>
-            `d = depth * (far - n ear) + n ear`
-          </p>
-        </li>
-      </ul>
     </section>
     <section>
       <h2>
@@ -517,18 +414,8 @@
         </p>
         <pre class="idl">
           partial dictionary MediaTrackSupportedConstraints {
-              // Apply to both depth stream track and color stream track:
+              // Applies to both depth stream track and color stream track:
               boolean videoKind = true;
-              boolean focalLengthX = false;
-              boolean focalLengthY = false;
-              boolean principalPointX = false;
-              boolean principalPointY = false;
-              boolean deprojectionDistortionCoefficients = false;
-              boolean projectionDistortionCoefficients = false;
-              // Apply to depth stream track:
-              boolean depthNear = false;
-              boolean depthFar = false;
-              boolean depthToVideoTransform = false;
           };
       
 </pre>
@@ -548,18 +435,8 @@
         </p>
         <pre class="idl">
           partial dictionary MediaTrackCapabilities {
-              // Apply to both depth stream track and color stream track:
+              // Applies to both depth stream track and color stream track:
               DOMString videoKind;
-              (double or DoubleRange) focalLengthX;
-              (double or DoubleRange) focalLengthY;
-              (double or DoubleRange) principalPointX;
-              (double or DoubleRange) principalPointY;
-              boolean deprojectionDistortionCoefficients;
-              boolean projectionDistortionCoefficients;
-              // Apply to depth stream track:
-              (double or DoubleRange) depthNear;
-              (double or DoubleRange) depthFar;
-              boolean depthToVideoTransform;
           };
 </pre>
       </section>
@@ -572,24 +449,13 @@
           <a>allowed values</a>.
         </p>
         <p>
-          The <dfn>allowed values</dfn> for <a>ConstrainDOMString</a>,
-          <a>ConstrainDouble</a>, and <a>ConstrainBoolean</a> types are defined
-          in [[!GETUSERMEDIA]] respectively.
+          The <dfn>allowed values</dfn> for <a>ConstrainDOMString</a> type are
+          defined in [[!GETUSERMEDIA]].
         </p>
         <pre class="idl">
           partial dictionary MediaTrackConstraintSet {
-              // Apply to both depth stream track and color stream track:
+              // Applies to both depth stream track and color stream track:
               ConstrainDOMString videoKind;
-              ConstrainDouble focalLengthX;
-              ConstrainDouble focalLengthY;
-              ConstrainDouble principalPointX;
-              ConstrainDouble principalPointY;
-              ConstrainBoolean deprojectionDistortionCoefficients;
-              ConstrainBoolean projectionDistortionCoefficients;
-              // Apply to depth stream track:
-              ConstrainDouble depthNear;
-              ConstrainDouble depthFar;
-              ConstrainBoolean depthToVideoTransform;
           };
 </pre>
       </section>
@@ -607,109 +473,21 @@
         </p>
         <pre class="idl">
           partial dictionary MediaTrackSettings {
-              // Apply to both depth stream track and color stream track:
+              // Applies to both depth stream track and color stream track:
               DOMString           videoKind;
-              double              focalLengthX;
-              double              focalLengthY;
-              double              principalPointX;
-              double              principalPointY;
-              DistortionCoefficients deprojectionDistortionCoefficients;
-              DistortionCoefficients projectionDistortionCoefficients;
-              // Apply to depth stream track:
-              double              depthNear;
-              double              depthFar;
-              Transformation      depthToVideoTransform;
           };
         
 </pre>
-        <section>
-          <h2>
-            <code>DistortionCoefficients</code> dictionary
-          </h2>
-          <pre class="idl">
-          dictionary DistortionCoefficients {
-              double              k1;
-              double              k2;
-              double              p1;
-              double              p2;
-              double              k3;
-          };
-        
-</pre>
-          <div data-dfn-for="DistortionCoefficients">
-            <p>
-              The <dfn><code>DistortionCoefficients</code></dfn> dictionary has
-              the <dfn>k1</dfn>, <dfn>k2</dfn>, <dfn>p1</dfn>, <dfn>p2</dfn>
-              and <dfn>k3</dfn> dictionary members that represent the
-              <a>deprojection distortion coefficients</a> or <a>projection
-              distortion coefficients</a>. <dfn data-dfn-for="k1">k1</dfn>,
-              <dfn data-dfn-for="k2">k2</dfn> and <dfn data-dfn-for=
-              "k3">k3</dfn> are <dfn>radial distortion coefficients</dfn> while
-              <dfn data-dfn-for="p1">p1</dfn> and <dfn data-dfn-for=
-              "p2">p2</dfn> are <dfn>tangential distortion coefficients</dfn>.
-              <a>Radial distortion coefficients</a> and <a>tangential
-              distortion coefficients</a> are used to <a>deproject</a> depth
-              value to 3D space or to <a>project</a> 3D value to 2D video frame
-              coordinates.
-            </p>
-            <p class="note">
-              See the <a>algorithm to map depth pixels to color pixels</a> and
-              Brown-Conrady distortion model implementation in <a>3D point
-              cloud rendering</a> example GLSL shader.<br>
-            </p>
-          </div>
-        </section>
-        <section>
-          <h2>
-            <code>Transformation</code> dictionary
-          </h2>
-          <pre class="idl">
-          dictionary Transformation {
-            Float32Array       transformationMatrix;
-            DOMString          videoDeviceId;
-          };
-        
-</pre>
-          <div data-dfn-for="Transformation">
-            <p>
-              The <dfn><code>Transformation</code></dfn> dictionary has the
-              <dfn><code>transformationMatrix</code></dfn> dictionary member
-              that is a 16 element array that defines the <a>transformation
-              matrix</a> of the <a>depth map</a>'s camera's 3D coordinate
-              system to video track's camera 3D coordinate system.
-            </p>
-            <p>
-              The first four elements of the array correspond to the first
-              matrix row, followed by four elements of the second matrix row
-              and so on. It is in format suitable for use with WebGL's
-              uniformMatrix4fv.
-            </p>
-            <p>
-              The <dfn><code>videoDeviceId</code></dfn> dictionary member
-              represents the <code>deviceId</code> of video camera the depth
-              stream must be synchronized with.
-            </p>
-            <p class="note">
-              The value of <a><code>videoDeviceId</code></a> can be used as the
-              <code>deviceId</code> constraint in [[!GETUSERMEDIA]] to get the
-              corresponding video and audio streams.
-            </p>
-          </div>
-        </section>
-      </section>
-      <section>
-        <h2>
-          Constrainable properties for color stream track and depth stream
-          track
-        </h2>
-        <p>
-          The following constrainable properties are defined to apply to both
-          <a>color stream track</a> and <a>depth stream track</a>.
-        </p>
         <section id="def-constraint-videoKind">
-          <h3>
-            <code>videoKind</code>
-          </h3>
+          <h2>
+            Video kind constrainable property
+          </h2>
+          <p>
+            The <code>videoKind</code> constrainable property is defined to
+            apply to both <a>color stream track</a> and <a>depth stream
+            track</a>. The <code>videoKind</code> member specifies the
+            <dfn>video kind</dfn> of the <a>source</a>.
+          </p>
           <p class="related">
             Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for=
             "MediaTrackSupportedConstraints">videoKind</dfn>,
@@ -720,16 +498,12 @@
             <a>MediaTrackSettings</a>.<dfn data-dfn-for=
             "MediaTrackSettings">videoKind</dfn>
           </p>
-          <p>
-            The <code>videoKind</code> member specifies the <dfn>video
-            kind</dfn> of the <a>source</a>.
-          </p>
           <pre class="idl">
-          enum VideoKindEnum {
-              "color",
-              "depth"
-          };
-          
+        enum VideoKindEnum {
+            "color",
+            "depth"
+        };
+        
 </pre>
           <p>
             The <dfn>VideoKindEnum</dfn> enumeration defines the valid <a>video
@@ -749,535 +523,87 @@
             <a>disabled</a>, it MUST render frames as if all the pixels would
             be 0.
           </p>
+        </section>
+        <section class="informative">
+          <h2>
+            WebGL implementation considerations
+          </h2>
           <div class="note">
-            <p>
-              A <a>color stream track</a> and a <a>depth stream track</a> can
-              be combined into one <a>depth+color stream</a>. The rendering of
-              the two tracks are intended to be synchronized. The resolution of
-              the two tracks are intended to be same. And the coordination of
-              the two tracks are intended to be calibrated. These are not hard
-              requirements, since it might not be possible to synchronize
-              tracks from sources.
-            </p>
-            <p>
-              This approach is simple to use but comes with the following
-              caveats: it might might not be supported by the implementation
-              and the resolutions of two tracks are intended to be the same
-              that can require downsampling and degrade quality. The
-              alternative approach is that a web developer implements the
-              <a>algorithm to map depth pixels to color pixels</a>. See the
-              <a>3D point cloud rendering</a> example code.
-            </p>
+            This section is currently work in progress, and subject to change.
           </div>
-        </section>
-        <section id="def-constraint-focalLengthX">
-          <h3>
-            <code>focalLengthX</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for=
-            "MediaTrackSupportedConstraints">focalLengthX</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for=
-            "MediaTrackCapabilities">focalLengthX</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for=
-            "MediaTrackConstraintSet">focalLengthX</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for=
-            "MediaTrackSettings">focalLengthX</dfn>
+          <p>
+            <a>Depth map</a> values that the camera produces are often in
+            16-bit <a>normalized</a> <a>unsigned fixed-point</a> format.
+            Application developer can access the data using <a>canvas pixel
+            arraybuffer</a> red color component, but that would cause a
+            precision loss given that it is in 8-bit <a>normalized</a>
+            <a>unsigned fixed-point</a> format.
           </p>
           <p>
-            The <code>focalLengthX</code> member specifies the <a>horizontal
-            focal length</a>, in pixels.
-          </p>
-        </section>
-        <section id="def-constraint-focalLengthY">
-          <h3>
-            <code>focalLengthY</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for=
-            "MediaTrackSupportedConstraints">focalLengthY</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for=
-            "MediaTrackCapabilities">focalLengthY</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for=
-            "MediaTrackConstraintSet">focalLengthY</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for=
-            "MediaTrackSettings">focalLengthY</dfn>
+            The same precision loss is related to usage of [[WEBGL]]
+            <code>UNSIGNED_BYTE</code> textures. In order to access the full
+            precision, application developer <a href="#dfn-uploaded">can
+            use</a> [[WEBGL]] <a>floating-point</a> textures.
           </p>
           <p>
-            The <code>focalLengthY</code> member specifies the <a>vertical
-            focal length</a>, in pixels.
-          </p>
-        </section>
-        <section id="def-constraint-principalPointX">
-          <h3>
-            <code>principalPointX</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for=
-            "MediaTrackSupportedConstraints">principalPointX</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for=
-            "MediaTrackCapabilities">principalPointX</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for=
-            "MediaTrackConstraintSet">principalPointX</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for=
-            "MediaTrackSettings">principalPointX</dfn>
+            There are several use-cases which are a good fit to be, at least
+            partially, implemented on the GPU, such as motion recognition,
+            pattern recognition, background removal, as well as 3D point cloud.
           </p>
           <p>
-            The <code>principalPointX</code> member specifies the <a>principal
-            point x</a> coordinate, in pixels.
+            This section explains which APIs can be used for some of these
+            mentioned use-cases; the concrete examples are provided in the
+            <a href="#examples">Examples</a> section.
           </p>
-        </section>
-        <section id="def-constraint-principalPointY">
-          <h3>
-            <code>principalPointY</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for=
-            "MediaTrackSupportedConstraints">principalPointY</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for=
-            "MediaTrackCapabilities">principalPointY</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for=
-            "MediaTrackConstraintSet">principalPointY</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for=
-            "MediaTrackSettings">principalPointY</dfn>
-          </p>
-          <p>
-            The <code>principalPointY</code> member specifies the <a>principal
-            point y</a> coordinate, in pixels.
-          </p>
-        </section>
-        <section id="def-constraint-deprojectionDistortionCoefficients">
-          <h3>
-            <code>deprojectionDistortionCoefficients</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for=
-            "MediaTrackSupportedConstraints">deprojectionDistortionCoefficients</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for=
-            "MediaTrackCapabilities">deprojectionDistortionCoefficients</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for=
-            "MediaTrackConstraintSet">deprojectionDistortionCoefficients</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for=
-            "MediaTrackSettings">deprojectionDistortionCoefficients</dfn>
-          </p>
-          <p>
-            The <code>deprojectionDistortionCoefficients</code> member
-            specifies the <a>MediaStreamTrack</a>'s <a>deprojection distortion
-            coefficients</a> used when deprojecting from 2D to 3D space.
-          </p>
-        </section>
-        <section id="def-constraint-projectionDistortionCoefficients">
-          <h3>
-            <code>projectionDistortionCoefficients</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for=
-            "MediaTrackSupportedConstraints">projectionDistortionCoefficients</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for=
-            "MediaTrackCapabilities">projectionDistortionCoefficients</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for=
-            "MediaTrackConstraintSet">projectionDistortionCoefficients</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for=
-            "MediaTrackSettings">projectionDistortionCoefficients</dfn>
-          </p>
-          <p>
-            The <code>projectionDistortionCoefficients</code> member specifies
-            the <a>MediaStreamTrack</a>'s <a>projection distortion
-            coefficients</a> used when deprojecting from 2D to 3D space.
-          </p>
-        </section>
-      </section>
-      <section>
-        <h2>
-          Constrainable properties for depth stream track
-        </h2>
-        <p>
-          The following constrainable properties are defined to apply only to
-          <a>depth stream track</a>.
-        </p>
-        <section id="def-constraint-depthNear-depthFar">
-          <h3>
-            <code>depthNear</code> and <code>depthFar</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for=
-            "MediaTrackSupportedConstraints">depthNear</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for=
-            "MediaTrackCapabilities">depthNear</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for=
-            "MediaTrackConstraintSet">depthNear</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for=
-            "MediaTrackSettings">depthNear</dfn>,
-            <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for=
-            "MediaTrackSupportedConstraints">depthFar</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for=
-            "MediaTrackCapabilities">depthFar</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for=
-            "MediaTrackConstraintSet">depthFar</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for=
-            "MediaTrackSettings">depthFar</dfn>
-          </p>
-          <p>
-            The <code>depthNear</code> member specifies the <a>near value</a>,
-            in meters.
-          </p>
-          <p>
-            The <code>depthFar</code> member specifies the <a>far value</a>, in
-            meters.
-          </p>
-          <p>
-            The <code>depthNear</code> and <code>depthFar</code> constrainable
-            properties, when set, allow the implementation to pick the best
-            depth camera mode optimized for the range <code>[depthNear,
-            depthFar]</code> and help minimize the error introduced by the
-            lossy conversion from the depth value <var>d</var> to a quantized
-            d<sub>8bit</sub> and back to an approximation of the depth value
-            <var>d</var>.
-          </p>
-          <p>
-            If the <code>depthFar</code> property's value is less than the
-            <code>depthNear</code> property's value, the <a>depth stream
-            track</a> is <a>overconstrained</a>.
-          </p>
-        </section>
-        <section id="def-constraint-depthToVideoTransform">
-          <h3>
-            <code>depthToVideoTransform</code>
-          </h3>
-          <p class="related">
-            Related: <a>MediaTrackSupportedConstraints</a>.<dfn data-dfn-for=
-            "MediaTrackSupportedConstraints">depthToVideoTransform</dfn>,
-            <a>MediaTrackCapabilities</a>.<dfn data-dfn-for=
-            "MediaTrackCapabilities">depthToVideoTransform</dfn>,
-            <a>MediaTrackConstraintSet</a>.<dfn data-dfn-for=
-            "MediaTrackConstraintSet">depthToVideoTransform</dfn>,
-            <a>MediaTrackSettings</a>.<dfn data-dfn-for=
-            "MediaTrackSettings">depthToVideoTransform</dfn>
-          </p>
-          <p>
-            The <code>depthToVideoTransform</code> member specifies the
-            <a>depth map</a>'s camera's <a>transformation from depth to
-            video</a> camera 3D coordinate system.
-          </p>
+          <section>
+            <h3>
+              Upload video frame to WebGL texture
+            </h3>
+            <p>
+              A <a>video</a> element whose source is a <a>MediaStream</a>
+              object containing a <a>depth stream track</a> may be
+              <dfn>uploaded</dfn> to a [[WEBGL]] texture of format
+              <code>RGBA</code> or <code>RED</code> and type
+              <code>FLOAT</code>. See the specification [[WEBGL]] and the
+              <a>upload to float texture</a> example code.
+            </p>
+            <p>
+              For each pixel of this WebGL texture, the R component represents
+              <a>normalized</a> <a>floating-point</a> <a>depth map value</a>.
+            </p>
+          </section>
+          <section>
+            <h3>
+              Read the data from a WebGL texture
+            </h3>
+            <p>
+              Here we list some of the possible approaches.
+            </p>
+            <ul>
+              <li>Synchronous readPixels usage requires the least amount of
+              code and it is available with WebGL 1.0. See the <a>readPixels
+              from float</a> example for further details.
+              </li>
+              <li>Asynchronous readPixels using pixel buffer objects to avoid
+              blocking the readPixels call.
+              </li>
+              <li>Transform feedback [[WEBGL2]] with GetBufferSubData(Async)
+              [[WEBGL-GET-BUFFER-SUB-DATA-ASYNC]] provides synchronous and
+              asynchronous read access to depth and color texture data
+              processed in the vertex shader.
+              </li>
+            </ul>
+          </section>
         </section>
       </section>
       <section class="informative">
         <h2>
-          WebGL implementation considerations
+          Examples
         </h2>
-        <div class="note">
-          This section is currently work in progress, and subject to change.
-        </div>
-        <p>
-          <a>Depth map</a> values that the camera produces are often in 16-bit
-          <a>normalized</a> <a>unsigned fixed-point</a> format. Application
-          developer can access the data using <a>canvas pixel arraybuffer</a>
-          red color component, but that would cause a precision loss given that
-          it is in 8-bit <a>normalized</a> <a>unsigned fixed-point</a> format.
-        </p>
-        <p>
-          The same precision loss is related to usage of [[WEBGL]]
-          <code>UNSIGNED_BYTE</code> textures. In order to access the full
-          precision, application developer <a href="#dfn-uploaded">can use</a>
-          [[WEBGL]] <a>floating-point</a> textures.
-        </p>
-        <p>
-          There are several use-cases which are a good fit to be, at least
-          partially, implemented on the GPU, such as motion recognition,
-          pattern recognition, background removal, as well as 3D point cloud.
-        </p>
-        <p>
-          This section explains which APIs can be used for some of these
-          mentioned use-cases; the concrete examples are provided in the
-          <a href="#examples">Examples</a> section.
-        </p>
-        <section>
-          <h3>
-            Upload video frame to WebGL texture
-          </h3>
-          <p>
-            A <a>video</a> element whose source is a <a>MediaStream</a> object
-            containing a <a>depth stream track</a> may be <dfn>uploaded</dfn>
-            to a [[WEBGL]] texture of format <code>RGBA</code> or
-            <code>RED</code> and type <code>FLOAT</code>. See the specification
-            [[WEBGL]] and the <a>upload to float texture</a> example code.
-          </p>
-          <p>
-            For each pixel of this WebGL texture, the R component represents
-            <a>normalized</a> <a>floating-point</a> <a>depth map value</a>.
-          </p>
-        </section>
-        <section>
-          <h3>
-            Read the data from a WebGL texture
-          </h3>
-          <p>
-            Here we list some of the possible approaches.
-          </p>
-          <ul>
-            <li>Synchronous readPixels usage requires the least amount of code
-            and it is available with WebGL 1.0. See the <a>readPixels from
-            float</a> example for further details.
-            </li>
-            <li>Asynchronous readPixels using pixel buffer objects to avoid
-            blocking the readPixels call.
-            </li>
-            <li>Transform feedback [[WEBGL2]] with GetBufferSubData(Async)
-            [[WEBGL-GET-BUFFER-SUB-DATA-ASYNC]] provides synchronous and
-            asynchronous read access to depth and color texture data processed
-            in the vertex shader.
-            </li>
-          </ul>
-        </section>
-      </section>
-    </section>
-    <section class="informative">
-      <h2>
-        Synchronizing depth and color video rendering
-      </h2>
-      <p class="note">
-        The algorithms presented in this section explain how a web developer
-        can <dfn>map depth and color</dfn> pixels. Concrete example on how to
-        do the mapping is provided in example vertex shader used for <a>3D
-        point cloud rendering</a>.
-      </p>
-      <p></p>
-      <p>
-        When rendering, we want to position a color value from color video
-        frame to corresponding <a>depth map value</a> or 3D point in space
-        defined by <a>depth map value</a>. We use <a>deprojection distortion
-        coefficients</a> to compensate camera distortion when deprojecting 2D
-        pixel coordinates to 3D space coordinates and <a>projection distortion
-        coefficients</a> in the opposite case, when projecting camera 3D space
-        points to pixels.
-      </p>
-      <p>
-        The <dfn>algorithm to map depth pixels to color pixels</dfn> is as
-        follows:
-      </p>
-      <ol>
-        <li>
-          <a>Deproject</a> <a>depth map value</a> to point in depth 3D space.
-        </li>
-        <li>
-          <a>Transform</a> 3D point from depth camera 3D space to color camera
-          3D space.
-        </li>
-        <li>
-          <a>Project</a> from color camera 3D space to color frame 2D pixels.
-        </li>
-      </ol>
-      <p></p>
-      <section>
-        <h2>
-          Deproject to depth 3D space
-        </h2>
-        <p>
-          The algorithm to <dfn>deproject</dfn> depth map value to point in
-          depth camera is as follows:
-        </p>
-        <p>
-          Let <var>dx</var> and <var>dy</var> be 2D coordinates, in pixels, of
-          a pixel in <a>depth map</a>.
-        </p><var></var>
-        <p>
-          Let <var>dz</var> be <a>depth map value</a> of the same pixel in the
-          <a>depth map</a>.
-        </p>
-        <p>
-          Let <var>fx</var> and <var>fy</var> be <a>depth map</a>'s
-          <a>horizontal focal length</a> and <a>vertical focal length</a>
-          respectively.
-        </p>
-        <p>
-          Let <var>cx</var> and <var>cy</var> be <a>depth map</a>'s
-          <a>principal point</a> 2D coordinates.
-        </p>
-        <p>
-          Let 3D coordinates (Xd, Yd, Zd) be the output of this step - a 3D
-          point in depth camera's 3D coordinate system.
-        </p>
-        <p>
-          `px = (dx - cx) / (fx)`
-        </p>
-        <p>
-          `py = (dy - cy) / (fy)`
-        </p>
-        <ul>
-          <li>If <a>depth map</a>'s <a>deprojection distortion coefficients</a>
-          are <a>not present</a> in <a href=
-          "#mediatracksettings-dictionary">MediaTrackSettings</a> dictionary,
-            <p>
-              3D coordinates (Xd, Yd, Zd) in depth camera space are calculated
-              as:
-            </p>
-            <p>
-              `Xd = dz * px`
-            </p>
-            <p>
-              `Yd = dz * px`
-            </p>
-            <p>
-              `Zd = dz`
-            </p>
-          </li>
-          <li>If <a>depth map</a>'s <a>deprojection distortion coefficients</a>
-          <a>k1</a>, <a>k2</a>, <a>k3</a>, <a>p1</a> and <a>p2</a> are
-          <a>present</a> in <a href=
-          "#mediatracksettings-dictionary">MediaTrackSettings</a> dictionary,
-          with a note that some of those could be zero,
-            <p>
-              3D coordinates (Xd, Yd, Zd) in depth camera space are calculated
-              as:
-            </p>
-            <p>
-              `r2 = px^2 + py^2`
-            </p>
-            <p>
-              `r = 1 + k1 * r2 + k2 * r2^2 + k3 * r2^3`
-            </p>
-            <p>
-              `Xd = dz * (px * r + 2 * p1 * px * py + p2 * (r2 + 2 * px^2))`
-            </p>
-            <p>
-              `Yd = dz * (py * r + 2 * p2 * px * py + p1 * (r2 + 2 * py^2))`
-            </p>
-            <p>
-              `Zd = dz`
-            </p>
-          </li>
-        </ul>
-        <p class="note">
-          See depth_deproject function in <a>3D point cloud rendering</a>
-          example.
-        </p>
-      </section>
-      <section>
-        <h2>
-          Transform from depth to color 3D space
-        </h2>
-        <p>
-          The result of <a>project</a> depth value to 3D point step, 3D point
-          (Xd, Yd, Zd), is in depth camera 3D coordinate system. To
-          <dfn>transform</dfn> coordinates of the same point in space, but to
-          color camera 3D coordinate system, we use matrix multiplication of
-          <a>transformation from depth to video</a> matrix by the (Xd, Yd, Zd)
-          3D point vector.
-        </p>
-        <p>
-          Let (Xc, Yc, Zc) be the output of this step - a 3D coordinates of
-          projected <a>depth map value</a> to color camera 3D space.
-        </p>
-        <p>
-          Let <var>M</var> be <a>transformation matrix</a> defined in <a>depth
-          map</a>'s <a data-link-for=
-          "MediaTrackSettings">depthToVideoTransform</a> field.
-        </p>
-        <p>
-          To multiply 4x4 matrix by 3 element vector, we extend the 3D vector
-          by one element to 4 dimensional vector. After multiplication, we use
-          vector's x, y and z coordinates as the result.
-        </p>
-        <p>
-          `((Xc), (Yc), (Zc)) = ([M] xx ((Xd), (Yd), (Zd), (1))).xyz`
-        </p>
-        <p class="note">
-          In <a>3D point cloud rendering</a> example, this is done by:
-          <code>vec4 color_point = u_depth_to_color * vec4(depth_point,
-          1.0);</code>
-        </p>
-      </section>
-      <section>
-        <h2>
-          Project from color 3D to pixel
-        </h2>
-        <p>
-          To <dfn>project</dfn> from color 3D to 2D coordinate we use the
-          corresponding color track's <a href=
-          "#mediatracksettings-dictionary">MediaTrackSettings</a>. The color
-          track we get using <a>depth map</a>'s <a data-link-for=
-          "MediaTrackSettings">Transformation</a>.<a>videoDeviceId</a> - it
-          represents the target color video deviceID that should be used as a
-          constraint with [[!GETUSERMEDIA]] call to get the corresponding color
-          video stream track. After that, we use color track
-          <a>getSettings()</a> to access <a href=
-          "#mediatracksettings-dictionary">MediaTrackSettings</a>.
-        </p>
-        <p>
-          Let `fx_c` and `fy_c` be color track's <a>horizontal focal length</a>
-          and <a>vertical focal length</a> respectively.
-        </p>
-        <p>
-          Let `cx_c` and `cy_c` be color track's <a>principal point</a> 2D
-          coordinates.
-        </p>
-        <p>
-          The result of this step is 2D coordinate of pixel in color video
-          frame (<var>x</var>, <var>y</var>).
-        </p>
-        <ul>
-          <li>If color track's <a>projection distortion coefficients</a>
-          <a>k1</a>, <a>k2</a>, <a>k3</a>, <a>p1</a> and <a>p2</a> are
-          <a>present</a> in <a href=
-          "#mediatracksettings-dictionary">MediaTrackSettings</a> dictionary,
-            <p>
-              position of pixel in color frame image (x, y) is calculated as:
-            </p>
-            <p>
-              `r2_c = (Xc)^2 + (Yc)^2`
-            </p>
-            <p>
-              `r = 1 + k1 * r2 + k2 * r2^2 + k3 * r2^3`
-            </p>
-            <p>
-              `px_c = r * (Xc) / (Zc)`
-            </p>
-            <p>
-              `py_c = r * (Yc) / (Zc)`
-            </p>
-            <p>
-              `x = (px_c + 2 * p1 * px_c * py_c + p2 * (r2_c + 2 * px_c^2)) *
-              fx_c + cx_c`
-            </p>
-            <p>
-              `y = (py_c + 2 * p2 * px_c * py_c + p1 * (r2_c + 2 * py_c^2)) *
-              fy_c + cy_c`
-            </p>
-          </li>
-          <li>If color track's <a>projection distortion coefficients</a> are
-          <a>not present</a> in <a href=
-          "#mediatracksettings-dictionary">MediaTrackSettings</a> dictionary,
-            <p>
-              position of pixel in color frame image (x, y) is calculated as:
-            </p>
-            <p>
-              `px_c = (Xc) / (Zc)`
-            </p>
-            <p>
-              `py_c = (Yc) / (Zc)`
-            </p>
-            <p>
-              `x = px_c * fx_c + cx_c`
-            </p>
-            <p>
-              `y = py_c * fy_c + cy_c`
-            </p>
-          </li>
-        </ul>
-        <p class="note">
-          See color_project function in <a>3D point cloud rendering</a>
-          example.
-        </p>
-      </section>
-    </section>
-    <section class="informative">
-      <h2>
-        Examples
-      </h2>
-      <h3>
-        Playback of depth and color streams from same device group.
-      </h3>
-      <pre class="example">
+        <h3>
+          Playback of depth and color streams from same device group.
+        </h3>
+        <pre class="example">
 navigator.mediaDevices.getUserMedia({
   video: {videoKind: {exact: "color"}, groupId: {exact: id}}
 }).then(function (stream) {
@@ -1300,14 +626,14 @@ navigator.mediaDevices.getUserMedia({
   }
 );
 </pre>
-      <h3>
-        WebGL: <dfn>upload to float texture</dfn>
-      </h3>
-      <p>
-        This code sets up a video element from a depth stream, uploads it to a
-        WebGL 2.0 float texture.
-      </p>
-      <pre class="example">
+        <h3>
+          WebGL: <dfn>upload to float texture</dfn>
+        </h3>
+        <p>
+          This code sets up a video element from a depth stream, uploads it to
+          a WebGL 2.0 float texture.
+        </p>
+        <pre class="example">
 navigator.mediaDevices.getUserMedia({
   video: {videoKind: {exact: "depth"}}
 }).then(function (stream) {
@@ -1335,19 +661,19 @@ gl.texImage2D(
    depthVideo);
 
 </pre>
-      <h3>
-        WebGL: <dfn>readPixels from float</dfn> texture
-      </h3>
-      <p>
-        This example extends <a>upload to float texture</a> example.
-      </p>
-      <p>
-        This code creates the texture to which we will upload the depth video
-        frame. Then, it sets up a named framebuffer, attach the texture as
-        color attachment and, after uploading the depth video to the texture,
-        reads the texture content to Float32Array.
-      </p>
-      <pre class="example">
+        <h3>
+          WebGL: <dfn>readPixels from float</dfn> texture
+        </h3>
+        <p>
+          This example extends <a>upload to float texture</a> example.
+        </p>
+        <p>
+          This code creates the texture to which we will upload the depth video
+          frame. Then, it sets up a named framebuffer, attach the texture as
+          color attachment and, after uploading the depth video to the texture,
+          reads the texture content to Float32Array.
+        </p>
+        <pre class="example">
 // Initialize texture and framebuffer for reading back the texture.
 let depthTexture = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, depthTexture);
@@ -1392,125 +718,38 @@ gl.readPixels(
   buffer);
 
 </pre>
-      <div class="note">
+        <div class="note">
+          <p>
+            Use
+            <code>gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT);</code>
+            to check whether readPixels to gl.RED or gl.RGBA float is
+            supported.
+          </p>
+        </div>
+      </section>
+      <section class="informative">
+        <h2>
+          Privacy and security considerations
+        </h2>
         <p>
-          Use
-          <code>gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT);</code> to
-          check whether readPixels to gl.RED or gl.RGBA float is supported.
+          The <a href=
+          "https://w3c.github.io/mediacapture-main/#privacy-and-security-considerations">
+          privacy and security considerations</a> discussed in
+          [[!GETUSERMEDIA]] apply to this extension specification.
         </p>
-      </div>
-      <h3>
-        WebGL Vertex Shader that implements mapping color and depth
-      </h3>
-      <p>
-        This vertex shader is used for <dfn>3D point cloud rendering</dfn>. The
-        code here shows how the web developer can implement <a>algorithm to map
-        depth pixels to color pixels</a>. Draw call used is
-        glDrawArrays(GL_POINTS, 0, depthMap.width * depthMap.height). Shader
-        output is 3D position of vertices (gl_Position) and color texture
-        sampling coordinates per vertex.
-      </p>
-      <pre class="example">
-&lt;script id="fragment-shader" type="x-shader/x-fragment"&gt;#version 300 es
-#define DISTORTION_NONE 0
-#define USE_DEPTH_DEPROJECTION_DISTORTION_COEFFICIENTS 1
-#define USE_COLOR_PROJECTION_DISTORTION_COEFFICIENTS 2
-uniform mat4 u_mvp;
-uniform vec2 u_color_size;
-uniform vec2 u_depth_size;
-uniform highp usampler2D s_depth_texture;
-uniform float u_depth_scale_in_meter;
-uniform mat4 u_depth_to_color;
-uniform vec2 u_color_offset;
-uniform vec2 u_color_focal_length;
-uniform float u_color_coeffs[5];
-uniform int u_color_projection_distortion;
-uniform vec2 u_depth_offset;
-uniform vec2 u_depth_focal_length;
-uniform float u_depth_coeffs[5];
-uniform int u_depth_deprojection_distortion;
-out vec2 v_tex;
-
-vec3 depth_deproject(vec2 pixel, float depth)
-{
-  vec2 point = (pixel - u_depth_offset) / u_depth_focal_length;
-  if(u_depth_deprojection_distortion == USE_DEPTH_DEPROJECTION_DISTORTION_COEFFICIENTS)
-  {
-    float r2 = dot(point, point);
-    float f = 1.0 + u_depth_coeffs[0] * r2 + u_depth_coeffs[1] * r2 * r2 + u_depth_coeffs[4] * r2 * r2 * r2;
-    float ux = point.x * f + 2.0 * u_depth_coeffs[2] * point.x * point.y +
-               u_depth_coeffs[3] * (r2 + 2.0 * point.x * point.x);
-    float uy = point.y * f + 2.0 * u_depth_coeffs[3] * point.x * point.y +
-               u_depth_coeffs[2] * (r2 + 2.0 * point.y * point.y);
-    point = vec2(ux, uy);
-  }
-  return vec3(point * depth, depth);
-}
-
-vec2 color_project(vec3 point)
-{
-  vec2 pixel = point.xy / point.z;
-  if(u_color_projection_distortion == USE_COLOR_PROJECTION_DISTORTION_COEFFICIENTS)
-  {
-    float r2 = dot(pixel, pixel);
-    float f = 1.0 + u_color_coeffs[0] * r2 + u_color_coeffs[1] * r2 * r2 +
-              u_color_coeffs[4] * r2 * r2 * r2;
-    pixel = pixel * f;
-    float dx = pixel.x + 2.0 * u_color_coeffs[2] * pixel.x * pixel.y +
-               u_color_coeffs[3] * (r2 + 2.0 * pixel.x * pixel.x);
-    float dy = pixel.y + 2.0 * u_color_coeffs[3] * pixel.x * pixel.y +
-               u_color_coeffs[2] * (r2 + 2.0 * pixel.y * pixel.y);
-    pixel = vec2(dx, dy);
-  }
-  return pixel * u_color_focal_length + u_color_offset;
-}
-
-void main()
-{
-  vec2 depth_pixel;
-  // generate lattice pos; (0, 0) (1, 0) (2, 0) ... (w-1, h-1)
-  depth_pixel.x = mod(float(gl_VertexID) + 0.5, u_depth_size.x);
-  depth_pixel.y = clamp(floor(float(gl_VertexID) / u_depth_size.x) + 0.5, 0.0, u_depth_size.y);
-
-  // get depth
-  vec2 depth_tex_pos = depth_pixel / u_depth_size;
-  uint depth = texture(s_depth_texture, depth_tex_pos).r;
-  float depth_in_meter = float(depth) * u_depth_scale_in_meter;
-
-  vec3 depth_point = depth_deproject(depth_pixel, depth_in_meter);
-  vec4 color_point = u_depth_to_color * vec4(depth_point, 1.0);
-  vec2 color_pixel = color_project(color_point.xyz);
-
-  // map [0, w) to [0, 1]
-  v_tex = color_pixel / u_color_size;
-
-  gl_Position = u_mvp * vec4(depth_point, 1.0);
-}
-&lt;/script&gt;
-</pre>
+      </section>
+      <section class="appendix">
+        <h2>
+          Acknowledgements
+        </h2>
+        <p>
+          Thanks to everyone who contributed to the <a href=
+          "https://www.w3.org/wiki/Media_Capture_Depth_Stream_Extension">Use
+          Cases and Requirements</a>, sent feedback and comments. Special
+          thanks to Ningxin Hu for experimental implementations, as well as to
+          the Project Tango for their experiments.
+        </p>
+      </section><!--section id="idl-index" class="appendix"></section-->
     </section>
-    <section class="informative">
-      <h2>
-        Privacy and security considerations
-      </h2>
-      <p>
-        The <a href=
-        "https://w3c.github.io/mediacapture-main/#privacy-and-security-considerations">
-        privacy and security considerations</a> discussed in [[!GETUSERMEDIA]]
-        apply to this extension specification.
-      </p>
-    </section>
-    <section class="appendix">
-      <h2>
-        Acknowledgements
-      </h2>
-      <p>
-        Thanks to everyone who contributed to the <a href=
-        "https://www.w3.org/wiki/Media_Capture_Depth_Stream_Extension">Use
-        Cases and Requirements</a>, sent feedback and comments. Special thanks
-        to Ningxin Hu for experimental implementations, as well as to the
-        Project Tango for their experiments.
-      </p>
-    </section><!--section id="idl-index" class="appendix"></section-->
   </body>
 </html>

--- a/index.src.html
+++ b/index.src.html
@@ -244,10 +244,8 @@
       </p>
       <p>
         The <dfn data-cite=
-        "!GETUSERMEDIA#dom-mediadevices-getusermedia"><code>getUserMedia()</code></dfn>,
-        <dfn data-cite=
-        "!GETUSERMEDIA#dfn-getsettings"><code>getSettings()</code></dfn>
-        methods and the <dfn data-cite=
+        "!GETUSERMEDIA#dom-mediadevices-getusermedia"><code>getUserMedia()</code></dfn>
+        and the <dfn data-cite=
         "!GETUSERMEDIA#idl-def-NavigatorUserMediaSuccessCallback"><code>NavigatorUserMediaSuccessCallback</code></dfn>
         callback are defined in [[!GETUSERMEDIA]].
       </p>
@@ -270,11 +268,8 @@
       </p>
       <p>
         The <dfn data-cite="!HTML#the-video-element"><code>video</code></dfn>
-        element and <dfn data-cite=
-        "!HTML#imagedata"><code>ImageData</code></dfn> (and its <dfn data-cite=
-        "!HTML#dom-imagedata-data"><code>data</code></dfn> attribute and
-        <dfn data-cite="!HTML#canvas-pixel-arraybuffer">Canvas Pixel
-        <code>ArrayBuffer</code></dfn>), <dfn data-cite=
+        element, <dfn data-cite="!HTML#canvas-pixel-arraybuffer">Canvas Pixel
+        <code>ArrayBuffer</code></dfn>, <dfn data-cite=
         "!HTML#videotrack"><code>VideoTrack</code></dfn>, <dfn data-cite=
         "!HTML#htmlmediaelement"><code>HTMLMediaElement</code></dfn> (and its
         <dfn data-cite="!HTML#dom-media-srcobject"><code>srcObject</code></dfn>
@@ -285,27 +280,15 @@
         defined in [[!HTML]].
       </p>
       <p>
-        The terms <dfn data-cite="!HTML#media-data">media data</dfn>,
-        <dfn data-cite="!HTML#media-provider-object">media provider
-        object</dfn>, <dfn data-cite=
-        "!HTML#assigned-media-provider-object">assigned media provider
-        object</dfn>, and the concept <dfn data-cite=
-        "!HTML#potentially-playing">potentially playing</dfn> are defined in
-        [[!HTML]].
-      </p>
-      <p>
         The term <dfn data-cite="!PERMISSIONS#permission">permission</dfn> and
         the permission name "<dfn data-cite=
         "!PERMISSIONS#dom-permissionname-camera"><code>camera</code></dfn>" are
         defined in [[!PERMISSIONS]].
       </p>
       <p>
-        The <dfn data-cite="!WEBIDL#idl-DataView"><code>DataView</code></dfn>,
-        <dfn data-cite=
-        "!WEBIDL#idl-Uint8ClampedArray"><code>Uint8ClampedArray</code></dfn>,
-        and <code><dfn data-cite=
-        "!WEBIDL#idl-Uint16Array">Uint16Array</dfn></code> buffer source types
-        are defined in [[WEBIDL]].
+        The <dfn data-cite=
+        "!WEBIDL#idl-Float32Array"><code>Float32Array</code></dfn> buffer
+        source type is defined in [[WEBIDL]].
       </p>
       <p>
         The meaning of dictionary member being <dfn data-cite=

--- a/index.src.html
+++ b/index.src.html
@@ -245,16 +245,12 @@
       <p>
         The <dfn data-cite=
         "!GETUSERMEDIA#dom-mediadevices-getusermedia"><code>getUserMedia()</code></dfn>
-        and the <dfn data-cite=
-        "!GETUSERMEDIA#idl-def-NavigatorUserMediaSuccessCallback"><code>NavigatorUserMediaSuccessCallback</code></dfn>
-        callback are defined in [[!GETUSERMEDIA]].
+        is defined in [[!GETUSERMEDIA]].
       </p>
       <p>
-        The concepts <dfn data-cite="!GETUSERMEDIA#track-muted">muted</dfn>,
-        <dfn data-cite="!GETUSERMEDIA#track-enabled">disabled</dfn>, and
-        <dfn data-cite=
-        "!GETUSERMEDIA#event-mediastreamtrack-overconstrained"><code>overconstrained</code></dfn>
-        as applied to <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
+        The concepts <dfn data-cite="!GETUSERMEDIA#track-muted">muted</dfn> and
+        <dfn data-cite="!GETUSERMEDIA#track-enabled">disabled</dfn> as applied
+        to <a>MediaStreamTrack</a> are defined in [[!GETUSERMEDIA]].
       </p>
       <p>
         The terms <dfn data-cite="!GETUSERMEDIA#dfn-source">source</dfn> and
@@ -268,34 +264,14 @@
       </p>
       <p>
         The <dfn data-cite="!HTML#the-video-element"><code>video</code></dfn>
-        element, <dfn data-cite="!HTML#canvas-pixel-arraybuffer">Canvas Pixel
-        <code>ArrayBuffer</code></dfn>, <dfn data-cite=
-        "!HTML#videotrack"><code>VideoTrack</code></dfn>, <dfn data-cite=
-        "!HTML#htmlmediaelement"><code>HTMLMediaElement</code></dfn> (and its
-        <dfn data-cite="!HTML#dom-media-srcobject"><code>srcObject</code></dfn>
-        attribute), <dfn data-cite=
-        "!HTML#htmlvideoelement"><code>HTMLVideoElement</code></dfn> interfaces
-        and the <dfn data-cite=
-        "!HTML#canvasimagesource"><code>CanvasImageSource</code></dfn> enum are
-        defined in [[!HTML]].
-      </p>
-      <p>
-        The term <dfn data-cite="!PERMISSIONS#permission">permission</dfn> and
-        the permission name "<dfn data-cite=
-        "!PERMISSIONS#dom-permissionname-camera"><code>camera</code></dfn>" are
-        defined in [[!PERMISSIONS]].
-      </p>
-      <p>
-        The <dfn data-cite=
-        "!WEBIDL#idl-Float32Array"><code>Float32Array</code></dfn> buffer
-        source type is defined in [[WEBIDL]].
+        element and <dfn data-cite="!HTML#canvas-pixel-arraybuffer">Canvas
+        Pixel <code>ArrayBuffer</code></dfn> interfaces are defined in
+        [[!HTML]].
       </p>
       <p>
         The meaning of dictionary member being <dfn data-cite=
         "!WEBIDL#dfn-present">present</dfn> or <dfn data-cite=
-        "!WEBIDL#dfn-present">not present</dfn>, and its <dfn data-cite=
-        "!WEBIDL#dfn-dictionary-member-default-value">default value</dfn> are
-        defined in [[WEBIDL]].
+        "!WEBIDL#dfn-present">not present</dfn> is defined in [[WEBIDL]].
       </p>
     </section>
     <section>


### PR DESCRIPTION
Implemented experiments [1] showed that:
* Application could be responsible to provide the values based
  on camera name, with no need to obtain the values from hardware.
* There is no standardized approach to obtain the calibration
  parameters, by browser from hardware.

This simplifies the specification and makes it in line with already
implemented (in Blink) videoKind property.

[1] https://github.com/01org/depth-camera-web-demo


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/astojilj/mediacapture-depth/pull/168.html" title="Last updated on Mar 1, 2019, 9:16 AM UTC (085a708)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-depth/168/2fcaff8...astojilj:085a708.html" title="Last updated on Mar 1, 2019, 9:16 AM UTC (085a708)">Diff</a>