### PR TITLE
Remove reference to unsupported GetBufferSubDataAsync extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,16 +97,6 @@
             ],
             "date": "3 November 2016",
             publisher: "Khronos"
-          },
-          "WEBGL-GET-BUFFER-SUB-DATA-ASYNC": {
-            title:     "WebGL WEBGL_get_buffer_sub_data_async Extension Draft Specification",
-            href:      "https://www.khronos.org/registry/webgl/extensions/WEBGL_get_buffer_sub_data_async/",
-            authors:   [
-              "Kai Ninomiya, Google Inc.",
-              "Members of WebGL working group"
-            ],
-            "date": "13 December 2016",
-            publisher: "Khronos"
           }
         }
     };
@@ -507,13 +497,10 @@
               code and it is available with WebGL 1.0. See the <a>readPixels
               from float</a> example for further details.
               </li>
-              <li>Asynchronous readPixels using pixel buffer objects to avoid
-              blocking the readPixels call.
-              </li>
-              <li>Transform feedback [[WEBGL2]] with GetBufferSubData(Async)
-              [[WEBGL-GET-BUFFER-SUB-DATA-ASYNC]] provides synchronous and
-              asynchronous read access to depth and color texture data
-              processed in the vertex shader.
+              <li>Using GetBufferSubData after WebGLSync's status signals that
+              readPixels (read to pixel buffer objects) or transform feedback
+              [[WEBGL2]] is complete, enables asynchronous, non-blocking read
+              of depth data from GPU.
               </li>
             </ul>
           </section>

--- a/index.src.html
+++ b/index.src.html
@@ -99,16 +99,6 @@
             ],
             "date": "3 November 2016",
             publisher: "Khronos"
-          },
-          "WEBGL-GET-BUFFER-SUB-DATA-ASYNC": {
-            title:     "WebGL WEBGL_get_buffer_sub_data_async Extension Draft Specification",
-            href:      "https://www.khronos.org/registry/webgl/extensions/WEBGL_get_buffer_sub_data_async/",
-            authors:   [
-              "Kai Ninomiya, Google Inc.",
-              "Members of WebGL working group"
-            ],
-            "date": "13 December 2016",
-            publisher: "Khronos"
           }
         }
     };
@@ -543,13 +533,10 @@
               code and it is available with WebGL 1.0. See the <a>readPixels
               from float</a> example for further details.
               </li>
-              <li>Asynchronous readPixels using pixel buffer objects to avoid
-              blocking the readPixels call.
-              </li>
-              <li>Transform feedback [[WEBGL2]] with GetBufferSubData(Async)
-              [[WEBGL-GET-BUFFER-SUB-DATA-ASYNC]] provides synchronous and
-              asynchronous read access to depth and color texture data
-              processed in the vertex shader.
+              <li>Using GetBufferSubData after WebGLSync's status signals that
+              readPixels (read to pixel buffer objects) or transform feedback
+              [[WEBGL2]] is complete, enables asynchronous, non-blocking read
+              of depth data from GPU.
               </li>
             </ul>
           </section>


### PR DESCRIPTION
Instead, developers need to use approach where GetBufferSunData is
issued after WebGLSync's status signals complete. If so,
GetBufferSubData is non-blocking call.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/astojilj/mediacapture-depth/pull/171.html" title="Last updated on Mar 4, 2019, 9:48 AM UTC (1d713a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-depth/171/36e4eb0...astojilj:1d713a5.html" title="Last updated on Mar 4, 2019, 9:48 AM UTC (1d713a5)">Diff</a>